### PR TITLE
Support Inflections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,8 @@ lib-ruby-parser = "4.0.4"
 md5 = "0.7.0"
 serde_json = "1.0.96"
 line-col = "0.2.1"
-ruby_inflector = "0.0.5"
+# ruby_inflector = { path = "../ruby_inflector" }
+ruby_inflector = '0.0.8'
 serde_magnus = "0.2.2"
 dashmap = "5.4.0"
 

--- a/src/packs/inflector_shim.rs
+++ b/src/packs/inflector_shim.rs
@@ -1,13 +1,18 @@
+use std::collections::HashSet;
+
 use regex::Regex;
-use ruby_inflector::{
-    case::{to_case_camel_like, CamelOptions},
-    Inflector,
+use ruby_inflector::case::{
+    to_case_camel_like, to_class_case as to_class_case_original, CamelOptions,
 };
 
 // See https://github.com/whatisinternet/Inflector/pull/87
 // Note that as of the PR that adds this comment, we are now using https://github.com/alexevanczuk/ruby_inflector,
 // so that we have an easier time making this inflector more specific to ruby applications (for now)
-pub fn to_class_case(s: &str, should_singularize: bool) -> String {
+pub fn to_class_case(
+    s: &str,
+    should_singularize: bool,
+    acronyms: &HashSet<String>,
+) -> String {
     let options = CamelOptions {
         new_word: true,
         last_char: ' ',
@@ -18,9 +23,9 @@ pub fn to_class_case(s: &str, should_singularize: bool) -> String {
     };
 
     let mut class_name = if should_singularize {
-        s.to_class_case()
+        to_class_case_original(s, acronyms)
     } else {
-        to_case_camel_like(s, options)
+        to_case_camel_like(s, options, acronyms)
     };
 
     // let mut class_name = s.to_class_case();
@@ -60,15 +65,16 @@ mod tests {
 
     #[test]
     fn test_trivial() {
-        let actual = to_class_case("my_string", false);
+        let actual = to_class_case("my_string", false, &HashSet::new());
         let expected = "MyString";
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn test_digits() {
-        let actual = to_class_case("my_string_401k_thing", false);
-        let expected = "MyString401KThing";
+        let actual =
+            to_class_case("my_string_401k_thing", false, &HashSet::new());
+        let expected = "MyString401kThing";
         assert_eq!(expected, actual);
     }
 }

--- a/src/packs/parser/ruby/packwerk/extractor.rs
+++ b/src/packs/parser/ruby/packwerk/extractor.rs
@@ -4,7 +4,11 @@ use lib_ruby_parser::{
 };
 use line_col::LineColLookup;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fs, path::Path};
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::Path,
+};
 
 use crate::packs::parser::ruby::namespace_calculator;
 
@@ -262,7 +266,11 @@ impl<'a> Visitor for ReferenceCollector<'a> {
                 if name.is_none() {
                     // We singularize here because by convention Rails will singularize the class name as declared via a symbol,
                     // e.g. `has_many :companies` will look for a class named `Company`, not `Companies`
-                    name = Some(to_class_case(&d.name.to_string_lossy(), true));
+                    name = Some(to_class_case(
+                        &d.name.to_string_lossy(),
+                        true,
+                        &HashSet::new(), // todo: pass in acronyms here
+                    ));
                 }
             }
 

--- a/tests/fixtures/app_with_inflections/app/services/some_api_class.rb
+++ b/tests/fixtures/app_with_inflections/app/services/some_api_class.rb
@@ -1,0 +1,1 @@
+class SomeRootClass; end

--- a/tests/fixtures/app_with_inflections/config/initializers/inflections.rb
+++ b/tests/fixtures/app_with_inflections/config/initializers/inflections.rb
@@ -1,0 +1,3 @@
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.acronym 'API'
+end

--- a/tests/fixtures/app_with_inflections/packwerk.yml
+++ b/tests/fixtures/app_with_inflections/packwerk.yml
@@ -1,0 +1,23 @@
+# See: Setting up the configuration file
+# https://github.com/Shopify/packwerk/blob/main/USAGE.md#setting-up-the-configuration-file
+
+# List of patterns for folder paths to include
+# include:
+# - "**/*.{rb,rake,erb}"
+
+# List of patterns for folder paths to exclude
+# exclude:
+# - "{bin,node_modules,script,tmp,vendor}/**/*"
+
+# Patterns to find package configuration files
+# package_paths: "**/"
+
+# List of custom associations, if any
+# custom_associations:
+# - "cache_belongs_to"
+
+# Whether or not you want the cache enabled (disabled by default)
+# cache: true
+
+# Where you want the cache to be stored (default below)
+# cache_directory: 'tmp/cache/packwerk'


### PR DESCRIPTION
This is a *first* attempt at trying to support parsing `config/initializers/inflections.rb`.

For example, if there is an acronym `API`, `to_class_case('some_api_error')` should be `SomeAPIError`.

We'll likely need to iterate on this!