### PR TITLE
Fix coupling of inflections to name of yielded param in inflections.rb and use of double vs. single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 A 100% Rust implementation of [packwerk](https://github.com/Shopify/packwerk), a gradual modularization platform for ruby.
 
 # Goals:
-## Drop-in replacement for `packwerk` on most projects
+## To be a drop-in replacement for `packwerk` on most projects
 - Currently can serve as a drop-in replacement on Gusto's extra-large Rails monolith
 - This is a work in progress! Please see [Verification](#verification) for instructions on how to verify the output of `packs` is the same as `packwerk`.
 
-## 20x faster than `packwerk` on most projects
+## To be 20x faster than `packwerk` on most projects
 - Currently ~10x as fast as the ruby implementation. See [Benchmarks](#benchmarks).
 - Your milemage may vary!
 - Other performance improvements are coming soon!

--- a/src/packs/parser/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parser/ruby/packwerk/constant_resolver.rs
@@ -1,4 +1,5 @@
 use rayon::prelude::{ParallelBridge, ParallelIterator};
+use regex::Regex;
 use tracing::debug;
 
 use std::{
@@ -75,8 +76,9 @@ impl ConstantResolver {
                 std::fs::read_to_string(inflections_path).unwrap();
             let inflections_lines = inflections_file.lines();
             for line in inflections_lines {
-                if line.contains("inflect.acronym") {
-                    let acronym = line.split('\'').nth(1).unwrap();
+                if line.contains(".acronym") {
+                    let re = Regex::new(r#"['\\"]"#).unwrap();
+                    let acronym = re.split(line).nth(1).unwrap();
                     acronyms.insert(acronym.to_string());
                 }
             }
@@ -410,6 +412,17 @@ mod tests {
             },
             resolver
                 .resolve(&String::from("::MyModule::SomeAPIClass"), &[])
+                .unwrap()
+        );
+
+        assert_eq!(
+            Constant {
+                fully_qualified_name: "::MyModule::SomeCSVClass".to_string(),
+                absolute_path_of_definition: absolute_root
+                    .join("app/services/my_module/some_csv_class.rb")
+            },
+            resolver
+                .resolve(&String::from("::MyModule::SomeCSVClass"), &[])
                 .unwrap()
         )
     }

--- a/src/packs/per_file_cache.rs
+++ b/src/packs/per_file_cache.rs
@@ -203,7 +203,7 @@ impl CachableFile {
     }
 }
 
-pub fn write_cache(
+fn write_cache(
     cachable_file: &CachableFile,
     references: Vec<UnresolvedReference>,
 ) {

--- a/tests/fixtures/app_with_inflections/app/services/my_module/some_csv_class.rb
+++ b/tests/fixtures/app_with_inflections/app/services/my_module/some_csv_class.rb
@@ -1,0 +1,4 @@
+module MyModule
+  class SomeCsvClass
+  end
+end

--- a/tests/fixtures/app_with_inflections/config/initializers/inflections.rb
+++ b/tests/fixtures/app_with_inflections/config/initializers/inflections.rb
@@ -1,3 +1,6 @@
-ActiveSupport::Inflector.inflections do |inflect|
-  inflect.acronym 'API'
+ActiveSupport::Inflector.inflections do |do_not_couple_implementation_to_this_string|
+  do_not_couple_implementation_to_this_string.acronym 'API'
+
+  # Using single vs double quotes inconsistently
+  do_not_couple_implementation_to_this_string.acronym "CSV"
 end


### PR DESCRIPTION
- update readme slightly
- fix coupling of inflections to name of yielded argument and use of double vs single quoted strings
