### PR TITLE
Allow for configurable public folders for privacy checker

### DIFF
--- a/src/packs.rs
+++ b/src/packs.rs
@@ -70,6 +70,8 @@ pub struct RawPack {
     visible_to: HashSet<String>,
     #[serde(default)]
     ignored_private_constants: HashSet<String>,
+    #[serde(default = "default_public_folder")]
+    public_folder: String,
     #[serde(default = "default_checker_setting")]
     enforce_dependencies: String,
     #[serde(default = "default_checker_setting")]
@@ -80,6 +82,10 @@ pub struct RawPack {
 
 fn default_checker_setting() -> String {
     "false".to_string()
+}
+
+fn default_public_folder() -> String {
+    "public".to_string()
 }
 
 // Make an enum for the configuration of a checker, which can be either false, true, or strict:
@@ -117,6 +123,7 @@ pub struct Pack {
     ignored_private_constants: HashSet<String>,
     package_todo: PackageTodo,
     visible_to: HashSet<String>,
+    public_folder: PathBuf,
     enforce_dependencies: CheckerSetting,
     enforce_privacy: CheckerSetting,
     enforce_visibility: CheckerSetting,
@@ -211,6 +218,7 @@ impl Pack {
 
         let dependencies = raw_pack.dependencies;
         let visible_to = raw_pack.visible_to;
+        let public_folder = relative_path.join(raw_pack.public_folder);
         let ignored_dependencies = raw_pack.ignored_dependencies;
         let ignored_private_constants = raw_pack.ignored_private_constants;
 
@@ -233,6 +241,7 @@ impl Pack {
             enforce_dependencies,
             enforce_privacy,
             enforce_visibility,
+            public_folder,
         };
 
         pack

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -85,7 +85,7 @@ fn default_checker_setting() -> String {
 }
 
 fn default_public_folder() -> String {
-    "public".to_string()
+    "app/public".to_string()
 }
 
 // Make an enum for the configuration of a checker, which can be either false, true, or strict:

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -77,25 +77,25 @@ impl CheckerInterface for Checker {
 mod tests {
     use super::*;
     use crate::packs::*;
-    use std::path::PathBuf;
 
     #[test]
     fn referencing_and_defining_pack_are_identical() {
         let checker = Checker {};
-        let configuration = configuration::get(
-            PathBuf::from("tests/fixtures/simple_app")
-                .canonicalize()
-                .expect("Could not canonicalize path")
-                .as_path(),
-        );
+
+        let defining_pack = Pack {
+            name: String::from("packs/foo"),
+            enforce_privacy: CheckerSetting::True,
+            ..Pack::default()
+        };
+
+        let referencing_pack = &Pack {
+            name: String::from("packs/foo"),
+            ..Pack::default()
+        };
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack: Some(
-                configuration.pack_set.for_pack(&String::from("packs/foo")),
-            ),
-            referencing_pack: configuration
-                .pack_set
-                .for_pack(&String::from("packs/foo")),
+            defining_pack: Some(&defining_pack),
+            referencing_pack,
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -110,20 +110,21 @@ mod tests {
     #[test]
     fn test_check() {
         let checker = Checker {};
-        let configuration = configuration::get(
-            PathBuf::from("tests/fixtures/simple_app")
-                .canonicalize()
-                .expect("Could not canonicalize path")
-                .as_path(),
-        );
+        let defining_pack = Pack {
+            name: String::from("packs/bar"),
+            enforce_privacy: CheckerSetting::True,
+            ..Pack::default()
+        };
+
+        let referencing_pack = &Pack {
+            name: String::from("packs/foo"),
+            ..Pack::default()
+        };
+
         let reference = Reference {
             constant_name: String::from("::Bar"),
-            defining_pack: Some(
-                configuration.pack_set.for_pack(&String::from("packs/bar")),
-            ),
-            referencing_pack: configuration
-                .pack_set
-                .for_pack(&String::from("packs/foo")),
+            defining_pack: Some(&defining_pack),
+            referencing_pack,
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -39,10 +39,12 @@ impl CheckerInterface for Checker {
 
         // This is a hack for now – we need to read package.yml file public_paths at some point,
         // and probably find a better way to check if the constant is public
+
+        let public_folder = defining_pack.relative_path.join("public");
         let is_public = relative_defining_file
             .as_ref()
             .unwrap()
-            .contains("/public/");
+            .starts_with(public_folder.to_string_lossy().as_ref());
 
         if is_public {
             return None;

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -116,7 +116,7 @@ mod tests {
         let defining_pack = Pack {
             name: String::from("packs/bar"),
             enforce_privacy: CheckerSetting::True,
-            public_folder: PathBuf::from("packs/bar/public"),
+            public_folder: PathBuf::from("packs/bar/app/public"),
             ..Pack::default()
         };
 
@@ -187,7 +187,7 @@ mod tests {
         let defining_pack = Pack {
             name: String::from("packs/bar"),
             enforce_privacy: CheckerSetting::True,
-            public_folder: PathBuf::from("packs/bar/public"),
+            public_folder: PathBuf::from("packs/bar/app/public"),
             ..Pack::default()
         };
 
@@ -227,7 +227,7 @@ mod tests {
         let checker = Checker {};
         let defining_pack = Pack {
             name: String::from("packs/bar"),
-            public_folder: PathBuf::from("packs/bar/api"),
+            public_folder: PathBuf::from("packs/bar/app/api"),
             enforce_privacy: CheckerSetting::True,
             ..Pack::default()
         };
@@ -245,7 +245,7 @@ mod tests {
                 "packs/foo/app/services/foo.rb",
             ),
             relative_defining_file: Some(String::from(
-                "packs/bar/api/app/services/bar.rb",
+                "packs/bar/app/api/bar.rb",
             )),
             source_location: SourceLocation { line: 3, column: 1 },
         };

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -176,4 +176,44 @@ mod tests {
 
         assert_eq!(None, checker.check(&reference))
     }
+
+    #[test]
+    fn test_public_folder_detection_works() {
+        let checker = Checker {};
+        let defining_pack = Pack {
+            name: String::from("packs/bar"),
+            enforce_privacy: CheckerSetting::True,
+            ..Pack::default()
+        };
+
+        let referencing_pack = &Pack {
+            name: String::from("packs/foo"),
+            ..Pack::default()
+        };
+
+        let reference = Reference {
+            constant_name: String::from("::Bar"),
+            defining_pack: Some(&defining_pack),
+            referencing_pack,
+            relative_referencing_file: String::from(
+                "packs/foo/app/services/foo.rb",
+            ),
+            relative_defining_file: Some(String::from(
+                "packs/bar/app/services/public/bar.rb",
+            )),
+            source_location: SourceLocation { line: 3, column: 1 },
+        };
+
+        let expected_violation = Violation {
+            message: String::from("privacy: packs/foo/app/services/foo.rb:3 references private constant ::Bar from packs/bar"),
+            identifier: ViolationIdentifier {
+                violation_type: String::from("privacy"),
+                file: String::from("packs/foo/app/services/foo.rb"),
+                constant_name: String::from("::Bar"),
+                referencing_pack_name: String::from("packs/foo"),
+                defining_pack_name: String::from("packs/bar"),
+            },
+        };
+        assert_eq!(expected_violation, checker.check(&reference).unwrap())
+    }
 }

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -260,6 +260,7 @@ mod tests {
                 package_todo: PackageTodo::default(),
                 ignored_dependencies: HashSet::new(),
                 ignored_private_constants: HashSet::new(),
+                public_folder: PathBuf::from("packs/bar/public"),
             },
             Pack {
                 enforce_dependencies: CheckerSetting::False,
@@ -273,6 +274,7 @@ mod tests {
                 package_todo: PackageTodo::default(),
                 ignored_dependencies: HashSet::new(),
                 ignored_private_constants: HashSet::new(),
+                public_folder: PathBuf::from("packs/baz/public"),
             },
             Pack {
                 enforce_dependencies: CheckerSetting::True,
@@ -288,6 +290,7 @@ mod tests {
                 package_todo: PackageTodo::default(),
                 ignored_dependencies: HashSet::new(),
                 ignored_private_constants: HashSet::new(),
+                public_folder: PathBuf::from("packs/foo/public"),
             },
             Pack {
                 enforce_dependencies: CheckerSetting::False,
@@ -301,6 +304,7 @@ mod tests {
                 package_todo: PackageTodo::default(),
                 ignored_dependencies: HashSet::new(),
                 ignored_private_constants: HashSet::new(),
+                public_folder: PathBuf::from("./public"),
             },
         ];
 

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -260,7 +260,7 @@ mod tests {
                 package_todo: PackageTodo::default(),
                 ignored_dependencies: HashSet::new(),
                 ignored_private_constants: HashSet::new(),
-                public_folder: PathBuf::from("packs/bar/public"),
+                public_folder: PathBuf::from("packs/bar/app/public"),
             },
             Pack {
                 enforce_dependencies: CheckerSetting::False,
@@ -274,7 +274,7 @@ mod tests {
                 package_todo: PackageTodo::default(),
                 ignored_dependencies: HashSet::new(),
                 ignored_private_constants: HashSet::new(),
-                public_folder: PathBuf::from("packs/baz/public"),
+                public_folder: PathBuf::from("packs/baz/app/public"),
             },
             Pack {
                 enforce_dependencies: CheckerSetting::True,
@@ -290,7 +290,7 @@ mod tests {
                 package_todo: PackageTodo::default(),
                 ignored_dependencies: HashSet::new(),
                 ignored_private_constants: HashSet::new(),
-                public_folder: PathBuf::from("packs/foo/public"),
+                public_folder: PathBuf::from("packs/foo/app/public"),
             },
             Pack {
                 enforce_dependencies: CheckerSetting::False,
@@ -304,7 +304,7 @@ mod tests {
                 package_todo: PackageTodo::default(),
                 ignored_dependencies: HashSet::new(),
                 ignored_private_constants: HashSet::new(),
-                public_folder: PathBuf::from("./public"),
+                public_folder: PathBuf::from("./app/public"),
             },
         ];
 


### PR DESCRIPTION
- simplify privacy tests to create pack structs
- write failing test
- fix bug
- allow overriding public folder
- default folder should be app/public not just public
