### PR TITLE
Make `packs` compatible with the VSCode Extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.33"
+version = "0.1.34"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ Options:
 # Installation
 See [INSTALLATION.md](https://github.com/alexevanczuk/packs/blob/main/INSTALLATION.md)
 
+# Using with VSCode Extension
+`packwerk` has a VSCode Extension: https://github.com/rubyatscale/packwerk-vscode/tree/main
+Using the extension with `packs` is straightforward and results in a much more responsive experience.
+
+Directions:
+- Follow [INSTALLATION.md](https://github.com/alexevanczuk/packs/blob/main/INSTALLATION.md) instructions to install `packs`
+- Follow the [configuration](https://github.com/rubyatscale/packwerk-vscode/tree/main#configuration) directions to configure the extension to use `packs` instead of the ruby gem by setting the executable to `packs check`
+
+
 # Verification
 As `packs` is still a work-in-progress, it's possible it will not produce the same results as the ruby implementation (see [Not Yet Supported](#not-yet-supported)). If so, please file an issue – I'd love to try to support your use case!
 

--- a/dev/notes.md
+++ b/dev/notes.md
@@ -20,7 +20,7 @@
 - [x] Generate `packwerk` compatible cache with `packs generate_cache`
 - [x] Parse ERB files
 - [x] `packs update`, which can be used to update `package_todo.yml`
-- [ ] `packs check`, which can be used as a drop-in replacement to the VSCode
+- [x] `packs check`, which can be used as a drop-in replacement to the VSCode
 
 # Profiling
 I've been using https://github.com/flamegraph-rs/flamegraph to generate flamegraphs to improve performance.

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -143,6 +143,12 @@ impl Hash for Pack {
     }
 }
 
+impl Pack {
+    fn relative_yml(&self) -> PathBuf {
+        self.relative_path.join("package.yml")
+    }
+}
+
 fn convert_raw_checker_setting(raw_checker_setting: &str) -> CheckerSetting {
     match raw_checker_setting {
         "false" => CheckerSetting::False,

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -158,7 +158,7 @@ pub(crate) fn check(
 
     if !unrecorded_violations.is_empty() {
         for violation in unrecorded_violations.iter() {
-            println!("{}", violation.message);
+            println!("{}\n", violation.message);
         }
 
         println!("{} violation(s) detected:", unrecorded_violations.len());

--- a/src/packs/checker/architecture.rs
+++ b/src/packs/checker/architecture.rs
@@ -70,17 +70,19 @@ impl CheckerInterface for Checker {
                 {
                     return None;
                 }
-                // .stdout(predicate::str::contains("architecture: packs/feature_flags/app/services/feature_flags.rb:2 references ::Payments from packs/payments (whose layer is `product`) from packs/feature_flags (whose layer is `utilities`)"));
+
                 let message = format!(
-                    "architecture: {}:{} references {} defined in {} (whose layer is `{}`) from {} (whose layer is `{}`)",
+                    "{}:{}:{}\nArchitecture violation: `{}` belongs to `{}` (whose layer is `{}`) cannot be accessed from `{}` (whose layer is `{}`)",
                     reference.relative_referencing_file,
                     reference.source_location.line,
+                    reference.source_location.column,
                     reference.constant_name,
                     defining_pack_name,
                     defining_layer,
                     referencing_pack_name,
                     referencing_layer,
                 );
+
                 let violation_type = String::from("architecture");
                 let file = reference.relative_referencing_file.clone();
                 let identifier = ViolationIdentifier {
@@ -175,7 +177,7 @@ mod tests {
         };
 
         let expected_violation = Violation {
-            message: String::from("architecture: packs/bar/app/services/bar.rb:3 references ::Foo defined in packs/foo (whose layer is `product`) from packs/bar (whose layer is `utilities`)"),
+            message: String::from("packs/bar/app/services/bar.rb:3:1\nArchitecture violation: `::Foo` belongs to `packs/foo` (whose layer is `product`) cannot be accessed from `packs/bar` (whose layer is `utilities`)"),
             identifier: ViolationIdentifier {
                 violation_type: String::from("architecture"),
                 file: String::from("packs/bar/app/services/bar.rb"),

--- a/src/packs/checker/visibility.rs
+++ b/src/packs/checker/visibility.rs
@@ -38,13 +38,15 @@ impl CheckerInterface for Checker {
         }
 
         let message = format!(
-            "visibility: {}:{} references {} from {}, which is not visible to {}",
+            "{}:{}:{}\nVisibility violation: `{}` belongs to `{}`, which is not visible to `{}`",
             reference.relative_referencing_file,
             reference.source_location.line,
+            reference.source_location.column,
             reference.constant_name,
             defining_pack_name,
-            referencing_pack_name
+            referencing_pack_name,
         );
+
         let violation_type = String::from("visibility");
         let file = reference.relative_referencing_file.clone();
         let identifier = ViolationIdentifier {
@@ -124,7 +126,7 @@ mod tests {
         };
 
         let expected_violation = Violation {
-            message: String::from("visibility: packs/bar/app/services/bar.rb:3 references ::Foo from packs/foo, which is not visible to packs/bar"),
+            message: String::from("packs/bar/app/services/bar.rb:3:1\nVisibility violation: `::Foo` belongs to `packs/foo`, which is not visible to `packs/bar`"),
             identifier: ViolationIdentifier {
                 violation_type: String::from("visibility"),
                 file: String::from("packs/bar/app/services/bar.rb"),

--- a/tests/architecture_violations_test.rs
+++ b/tests/architecture_violations_test.rs
@@ -13,7 +13,7 @@ fn test_check() -> Result<(), Box<dyn Error>> {
         .assert()
         .failure()
         .stdout(predicate::str::contains("1 violation(s) detected:"))
-        .stdout(predicate::str::contains("architecture: packs/feature_flags/app/services/feature_flags.rb:2 references ::Payments defined in packs/payments (whose layer is `product`) from packs/feature_flags (whose layer is `utilities`)"));
+        .stdout(predicate::str::contains("packs/feature_flags/app/services/feature_flags.rb:2:0\nArchitecture violation: `::Payments` belongs to `packs/payments` (whose layer is `product`) cannot be accessed from `packs/feature_flags` (whose layer is `utilities`)"));
 
     common::teardown();
     Ok(())

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -20,8 +20,8 @@ fn test_check() -> Result<(), Box<dyn Error>> {
         .assert()
         .failure()
         .stdout(predicate::str::contains("2 violation(s) detected:"))
-        .stdout(predicate::str::contains("dependency: packs/foo/app/services/foo.rb:3 references ::Bar from packs/bar without an explicit dependency in packs/foo/package.yml"))
-        .stdout(predicate::str::contains("privacy: packs/foo/app/services/foo.rb:3 references private constant ::Bar from packs/bar"));
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
 
     common::teardown();
     Ok(())


### PR DESCRIPTION
- Make error messages compatible with VSCode extension
- add instructions
- bump version
