### PR TITLE
Replace glob-match with globset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ path = "src/lib.rs"
 [dependencies]
 clap = { version = "4.2.1", features = ["derive"] } # cli
 clap_derive = "4.2.0" # cli
-glob-match = "0.2.1"
 itertools = "0.10.5" # tools for iterating over iterable things
 jwalk = "0.8.1"
 path-clean = "1.0.1" # Pathname#cleaname in Ruby
@@ -46,6 +45,7 @@ line-col = "0.2.1"
 ruby_inflector = '0.0.8'
 serde_magnus = "0.2.2"
 dashmap = "5.4.0"
+globset = "0.4.10"
 
 [dev-dependencies]
 assert_cmd = "2.0.10" # testing CLI

--- a/src/packs/walk_directory.rs
+++ b/src/packs/walk_directory.rs
@@ -88,7 +88,7 @@ pub fn walk_directory(
                         .unwrap()
                         .to_owned();
 
-                    if cloned_excluded_dirs.as_ref().is_match(&relative_path) {
+                    if cloned_excluded_dirs.as_ref().is_match(relative_path) {
                         dir_entry.read_children_path = None;
                     }
                 }


### PR DESCRIPTION
Replace [glob-match](https://github.com/devongovett/glob-match) with [globset](https://github.com/BurntSushi/ripgrep/tree/master/crates/globset) because https://github.com/devongovett/glob-match/issues/9 prevents some of the Ruby files from being included.

The performance is roughly the same. `packs2` is the version with the patch.

```
$ hyperfine --runs 50 'packs check' 'packs2 check'
Benchmark 1: packs check
  Time (mean ± σ):     947.9 ms ±  21.3 ms    [User: 1440.1 ms, System: 2817.1 ms]
  Range (min … max):   910.4 ms … 1019.3 ms    50 runs

Benchmark 2: packs2 check
  Time (mean ± σ):     938.9 ms ±  21.9 ms    [User: 1426.8 ms, System: 2826.5 ms]
  Range (min … max):   907.1 ms … 1001.6 ms    50 runs

Summary
  packs2 check ran
    1.01 ± 0.03 times faster than packs check
```

Note on `.literal_separator(true)`:
> `*` matches zero or more characters. (If the `literal_separator` option is enabled, then `*` can never match a path separator.)

(From https://docs.rs/globset/latest/globset/)