### PR TITLE
Borrow rather than clone memory in constant_resolver

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -10,9 +10,8 @@ hyperfine --runs=3 --export-markdown cold-cache-without-spring.md \
 
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `../pks/target/release/packs check` | 7.870 ± 0.379 | 7.468 | 8.222 | 1.00 |
-| `DISABLE_SPRING=1 bin/packwerk check` | 70.172 ± 5.335 | 66.240 | 76.246 | 8.92 ± 0.80 |
-
+| `../pks/target/release/packs check` | 7.413 ± 0.466 | 6.900 | 7.808 | 1.00 |
+| `DISABLE_SPRING=1 bin/packwerk check` | 88.359 ± 6.480 | 84.431 | 95.838 | 11.92 ± 1.15 |
 
 ## Hot Cache, without Spring
 ```
@@ -23,5 +22,5 @@ hyperfine --warmup=1 --runs=3 --export-markdown hot-cache-without-spring.md \
 
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `../pks/target/release/packs check` | 3.801 ± 0.046 | 3.771 | 3.854 | 1.00 |
-| `DISABLE_SPRING=1 bin/packwerk check` | 63.196 ± 18.210 | 42.169 | 73.746 | 16.63 ± 4.80 |
+| `../pks/target/release/packs check` | 3.429 ± 0.130 | 3.322 | 3.573 | 1.00 |
+| `DISABLE_SPRING=1 bin/packwerk check` | 40.475 ± 3.635 | 38.224 | 44.668 | 11.80 ± 1.15 |

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -50,10 +50,15 @@ impl<'a> Reference<'a> {
         unresolved_reference: &UnresolvedReference,
         referencing_file_path: &Path,
     ) -> Reference<'a> {
-        let maybe_constant = configuration.constant_resolver.resolve(
-            &unresolved_reference.name,
-            &unresolved_reference.namespace_path,
-        );
+        let str_references: Vec<&str> = unresolved_reference
+            .namespace_path
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<&str>>();
+
+        let maybe_constant = configuration
+            .constant_resolver
+            .resolve(&unresolved_reference.name, &str_references);
 
         let (defining_pack, relative_defining_file) = if let Some(constant) =
             &maybe_constant

--- a/src/packs/parser/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parser/ruby/packwerk/constant_resolver.rs
@@ -222,11 +222,7 @@ impl ConstantResolver {
 
         let fully_qualified_name_guess =
             fully_qualified_name_guess_vec.join("::");
-        // Join current_namespace_path and const_name with "::"
-        // current_namespace_path
-        //     .iter()
-        //     .chain(std::iter::once(const_name))
-        //     .join("::");
+
         if let Some(constant) =
             self.constant_for_fully_qualified_name(&fully_qualified_name_guess)
         {

--- a/src/packs/parser/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parser/ruby/packwerk/constant_resolver.rs
@@ -226,9 +226,10 @@ impl ConstantResolver {
         if let Some(constant) =
             self.constant_for_fully_qualified_name(&fully_qualified_name_guess)
         {
-            let x = current_namespace_path;
-            let y = &constant.absolute_path_of_definition;
-            (Some(x), Some(y))
+            (
+                Some(current_namespace_path),
+                Some(&constant.absolute_path_of_definition),
+            )
         } else {
             // In this case, we couldn't find a constant with the given name under the given namespace.
             // However, it's possible the constant is defined within the parent namespace.

--- a/src/packs/parser/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parser/ruby/packwerk/constant_resolver.rs
@@ -93,8 +93,7 @@ impl ConstantResolver {
             .iter()
             .par_bridge()
             .flat_map(|absolute_autoload_path| {
-                let mut glob_path = absolute_autoload_path.clone();
-                glob_path.push("**/*.rb");
+                let glob_path = absolute_autoload_path.join("**/*.rb");
 
                 let files = glob::glob(glob_path.to_str().unwrap())
                     .expect("Failed to read glob pattern")

--- a/src/packs/parser/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parser/ruby/packwerk/constant_resolver.rs
@@ -137,15 +137,15 @@ impl ConstantResolver {
         namespace_path: &[&str],
     ) -> Option<Constant> {
         // If the fully_or_partially_qualified_constant is prefixed with ::, the namespace path is technically empty, since it's a global reference
-        let namespace_path =
+        let (namespace_path, const_name) =
             if fully_or_partially_qualified_constant.starts_with("::") {
-                &[]
+                let const_name = fully_or_partially_qualified_constant
+                    .trim_start_matches("::");
+                let namespace_path: &[&str] = &[];
+                (namespace_path, const_name)
             } else {
-                namespace_path
+                (namespace_path, fully_or_partially_qualified_constant)
             };
-
-        let const_name =
-            fully_or_partially_qualified_constant.trim_start_matches("::");
 
         self.resolve_constant(const_name, namespace_path, const_name)
     }

--- a/src/packs/parser/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parser/ruby/packwerk/constant_resolver.rs
@@ -100,6 +100,7 @@ impl ConstantResolver {
                     .filter_map(Result::ok);
 
                 files
+                    .par_bridge()
                     .map(|file| {
                         inferred_constant_from_file(
                             &file,

--- a/src/packs/walk_directory.rs
+++ b/src/packs/walk_directory.rs
@@ -111,11 +111,16 @@ pub fn walk_directory(
         //     .open("tmp/pks_log.txt")
         //     .unwrap();
         // writeln!(file, "{:?}", entry).unwrap();
-        let absolute_path = entry.unwrap().path();
+        let unwrapped_entry = entry.unwrap();
 
-        if absolute_path.is_dir() {
+        // Note that we could also get the dir from absolute_path.is_dir()
+        // However, this data appears to be cached on the FileType struct, so we'll use that instead,
+        // which is much faster!
+        if unwrapped_entry.file_type.is_dir() {
             continue;
         }
+
+        let absolute_path = unwrapped_entry.path();
 
         let relative_path = absolute_path
             .strip_prefix(&absolute_root)


### PR DESCRIPTION
- Borrow rather than clones variables in constant resolver
- avoid trimming start matches unless we need to
- remove comment
- update benchmarks
