### PR TITLE
Use cache for constant resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.36"
+version = "0.1.37"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/dev/notes.md
+++ b/dev/notes.md
@@ -7,7 +7,6 @@
   - Convert existing cache to be `PackwerkCompatibleCache`.
   - Consider using SQLite cache (for less file IO)
   - We could consider caching the RESOLVED references in a file, which would allow us to potentially skip generating the constant resolver and resolving all of the unresolved constants. This makes cache invalidation more complex though, but it might work in the happy path.
-- Explore caching constant resolver
 
 ## Distribution
 - Sign the binary

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -68,8 +68,11 @@ pub(crate) fn get(absolute_root: &Path) -> Configuration {
 
     let cache_directory = absolute_root.join(raw_config.cache_directory);
     let cache_enabled = raw_config.cache;
-    let constant_resolver =
-        ConstantResolver::create(&absolute_root, autoload_paths);
+    let constant_resolver = ConstantResolver::create(
+        &absolute_root,
+        autoload_paths,
+        &cache_directory,
+    );
 
     let layers = Layers {
         layers: raw_config.architecture_layers,


### PR DESCRIPTION
This saves some time on building the constant resolver.

This in particular makes `packs check with/one/or/few/paths.rb` pretty fast (half second).

I'm also exploring building the constant resolver incrementally when walking the directory, but haven't found a way to do this that isn't *less* performant than the current implementation. For example, here's an alternate implementation: https://github.com/alexevanczuk/packs/pull/37

However, that implementation is actually less performant than the current one. It would be helpful to move towards that style of implementation (building it incrementally) because it would allow us to gracefully migrate to an approach where we parse files for definitions.