### PR TITLE
Move unresolved reference struct to better home

### DIFF
--- a/src/packs.rs
+++ b/src/packs.rs
@@ -25,9 +25,9 @@ pub use crate::packs::pack_set::PackSet;
 pub use configuration::Configuration;
 pub use package_todo::PackageTodo;
 pub use parser::ruby::packwerk::extractor::Range;
-pub use parser::ruby::packwerk::extractor::UnresolvedReference;
 
 use self::checker::ViolationIdentifier;
+use self::parser::UnresolvedReference;
 
 pub fn greet() {
     println!("👋 Hello! Welcome to packs 📦 🔥 🎉 🌈. This tool is under construction.")

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -24,7 +24,6 @@ pub use crate::packs::checker::Violation;
 pub use crate::packs::pack_set::PackSet;
 pub use configuration::Configuration;
 pub use package_todo::PackageTodo;
-pub use parser::ruby::packwerk::extractor::Range;
 
 use self::checker::ViolationIdentifier;
 use self::parser::UnresolvedReference;

--- a/src/packs/parser.rs
+++ b/src/packs/parser.rs
@@ -8,10 +8,11 @@ use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 pub(crate) use ruby::packwerk::extractor::process_from_path as process_from_ruby_path;
 pub(crate) mod erb;
 pub(crate) use erb::packwerk::extractor::process_from_path as process_from_erb_path;
+use serde::{Deserialize, Serialize};
 
 use super::{
     file_utils::{get_file_type, SupportedFileType},
-    ProcessedFile,
+    ProcessedFile, Range,
 };
 
 pub fn process_file(path: &Path) -> ProcessedFile {
@@ -29,6 +30,13 @@ pub fn process_file(path: &Path) -> ProcessedFile {
             unresolved_references: vec![],
         }
     }
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct UnresolvedReference {
+    pub name: String,
+    pub namespace_path: Vec<String>,
+    pub location: Range,
 }
 
 pub trait Cache {

--- a/src/packs/parser.rs
+++ b/src/packs/parser.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     file_utils::{get_file_type, SupportedFileType},
-    ProcessedFile, Range,
+    ProcessedFile,
 };
 
 pub fn process_file(path: &Path) -> ProcessedFile {
@@ -37,6 +37,26 @@ pub struct UnresolvedReference {
     pub name: String,
     pub namespace_path: Vec<String>,
     pub location: Range,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Default)]
+pub struct Range {
+    pub start_row: usize,
+    pub start_col: usize,
+    pub end_row: usize,
+    pub end_col: usize,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Location {
+    pub begin: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct LocationRange {
+    pub start: Location,
+    pub end: Location,
 }
 
 pub trait Cache {

--- a/src/packs/parser.rs
+++ b/src/packs/parser.rs
@@ -47,18 +47,6 @@ pub struct Range {
     pub end_col: usize,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct Location {
-    pub begin: usize,
-    pub end: usize,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct LocationRange {
-    pub start: Location,
-    pub end: Location,
-}
-
 pub trait Cache {
     fn process_file(&self, absolute_root: &Path, path: &Path) -> ProcessedFile;
 }

--- a/src/packs/parser/erb/packwerk.rs
+++ b/src/packs/parser/erb/packwerk.rs
@@ -6,7 +6,7 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::packs::parser::erb::packwerk::extractor::process_from_contents;
-    use crate::packs::Range;
+    use crate::packs::parser::Range;
     use crate::packs::UnresolvedReference;
 
     #[test]

--- a/src/packs/parser/erb/packwerk/extractor.rs
+++ b/src/packs/parser/erb/packwerk/extractor.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 
-use crate::packs::{ProcessedFile, Range, UnresolvedReference};
+use crate::packs::{parser::Range, ProcessedFile, UnresolvedReference};
 use std::{fs, path::Path};
 
 use crate::packs::parser::ruby::packwerk::extractor::process_from_contents as process_from_ruby_contents;

--- a/src/packs/parser/ruby/packwerk.rs
+++ b/src/packs/parser/ruby/packwerk.rs
@@ -6,7 +6,7 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::packs::parser::ruby::packwerk::extractor::process_from_contents;
-    use crate::packs::Range;
+    use crate::packs::parser::Range;
     use crate::packs::UnresolvedReference;
 
     #[test]

--- a/src/packs/parser/ruby/packwerk/extractor.rs
+++ b/src/packs/parser/ruby/packwerk/extractor.rs
@@ -1,4 +1,6 @@
-use crate::packs::{inflector_shim::to_class_case, ProcessedFile};
+use crate::packs::{
+    inflector_shim::to_class_case, parser::UnresolvedReference, ProcessedFile,
+};
 use lib_ruby_parser::{
     nodes, traverse::visitor::Visitor, Loc, Node, Parser, ParserOptions,
 };
@@ -13,19 +15,10 @@ use std::{
 use crate::packs::parser::ruby::namespace_calculator;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SuperclassReference {
+struct SuperclassReference {
     pub name: String,
     pub namespace_path: Vec<String>,
 }
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-// TODO: Move this to a more appropriate place
-pub struct UnresolvedReference {
-    pub name: String,
-    pub namespace_path: Vec<String>,
-    pub location: Range,
-}
-
 impl UnresolvedReference {
     fn possible_fully_qualified_constants(&self) -> Vec<String> {
         if self.name.starts_with("::") {

--- a/src/packs/parser/ruby/packwerk/extractor.rs
+++ b/src/packs/parser/ruby/packwerk/extractor.rs
@@ -1,5 +1,7 @@
 use crate::packs::{
-    inflector_shim::to_class_case, parser::UnresolvedReference, ProcessedFile,
+    inflector_shim::to_class_case,
+    parser::{Range, UnresolvedReference},
+    ProcessedFile,
 };
 use lib_ruby_parser::{
     nodes, traverse::visitor::Visitor, Loc, Node, Parser, ParserOptions,
@@ -19,6 +21,14 @@ struct SuperclassReference {
     pub name: String,
     pub namespace_path: Vec<String>,
 }
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Definition {
+    pub fully_qualified_name: String,
+    pub location: Range,
+    pub namespace_path: Vec<String>,
+}
+
 impl UnresolvedReference {
     fn possible_fully_qualified_constants(&self) -> Vec<String> {
         if self.name.starts_with("::") {
@@ -36,33 +46,6 @@ impl UnresolvedReference {
 
         possible_constants
     }
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct Definition {
-    pub fully_qualified_name: String,
-    pub location: Range,
-    pub namespace_path: Vec<String>,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Default)]
-pub struct Range {
-    pub start_row: usize,
-    pub start_col: usize,
-    pub end_row: usize,
-    pub end_col: usize,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct Location {
-    pub begin: usize,
-    pub end: usize,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct LocationRange {
-    pub start: Location,
-    pub end: Location,
 }
 
 struct ReferenceCollector<'a> {

--- a/src/packs/per_file_cache.rs
+++ b/src/packs/per_file_cache.rs
@@ -8,8 +8,8 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::path::PathBuf;
 
-use super::parser::Cache;
-use super::{ProcessedFile, Range, UnresolvedReference};
+use super::parser::{Cache, Range};
+use super::{ProcessedFile, UnresolvedReference};
 
 pub struct PerFileCache {
     pub cache_dir: PathBuf,


### PR DESCRIPTION
- Move UnresolvedReferences to better place
- Move other structs into parser
- remove unused struct
