### PR TITLE
Move most of ConstantResovler to zeitwerk_utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,4 @@ predicates = "3.0.2" # kind of like rspec assertions
 # see #[serial] tag for more info
 # more info: https://fdeantoni.medium.com/running-tests-sequentially-in-rust-eed7566f63f0
 serial_test = "2.0.0"
+pretty_assertions = "1.3.0" # Shows a more readable diff when comparing objects

--- a/src/packs/parsing/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parsing/ruby/packwerk/constant_resolver.rs
@@ -1,25 +1,14 @@
-use rayon::prelude::{ParallelBridge, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     path::{Path, PathBuf},
 };
 
-use crate::packs::parsing::ruby::rails_utils::get_acronyms_from_disk;
-
-#[derive(Serialize, Deserialize)]
-struct ConstantResolverCache {
-    file_definition_map: HashMap<PathBuf, String>,
-}
-
 #[derive(Default)]
 pub struct ConstantResolver {
-    fully_qualified_constant_to_constant_map: HashMap<String, Constant>,
-    // Just for testing
-    #[allow(dead_code)]
-    pub(crate) autoload_paths: Vec<PathBuf>,
+    pub fully_qualified_constant_to_constant_map: HashMap<String, Constant>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -28,153 +17,13 @@ pub struct Constant {
     pub absolute_path_of_definition: PathBuf,
 }
 
-fn inferred_constant_from_file(
-    absolute_path: &Path,
-    absolute_autoload_path: &PathBuf,
-    acronyms: &HashSet<String>,
-) -> Constant {
-    let relative_path =
-        absolute_path.strip_prefix(absolute_autoload_path).unwrap();
-
-    let relative_path = relative_path.with_extension("");
-
-    let relative_path_str = relative_path.to_str().unwrap();
-    let fully_qualified_constant_name =
-        crate::packs::inflector_shim::camelize(relative_path_str, acronyms);
-
-    Constant {
-        fully_qualified_name: fully_qualified_constant_name,
-        absolute_path_of_definition: absolute_path.to_path_buf(),
-    }
-}
-
-fn get_constant_resolver_cache(cache_dir: &Path) -> ConstantResolverCache {
-    let path = cache_dir.join("constant_resolver.json");
-    if path.exists() {
-        let file = std::fs::File::open(path).unwrap();
-        let reader = std::io::BufReader::new(file);
-        serde_json::from_reader(reader).unwrap()
-    } else {
-        ConstantResolverCache {
-            file_definition_map: HashMap::new(),
-        }
-    }
-}
-
-fn cache_constant_definitions(constants: &Vec<Constant>, cache_dir: &Path) {
-    let mut file_definition_map: HashMap<PathBuf, String> = HashMap::new();
-    for constant in constants {
-        file_definition_map.insert(
-            constant.absolute_path_of_definition.clone(),
-            constant.fully_qualified_name.clone(),
-        );
-    }
-
-    let cache_data_json = serde_json::to_string(&ConstantResolverCache {
-        file_definition_map,
-    })
-    .expect("Failed to serialize");
-
-    std::fs::create_dir_all(cache_dir).unwrap();
-    std::fs::write(cache_dir.join("constant_resolver.json"), cache_data_json)
-        .unwrap();
-}
-
 #[allow(unused_variables)]
 impl ConstantResolver {
     pub fn create(
         absolute_root: &Path,
-        autoload_paths: Vec<PathBuf>,
-        cache_dir: &Path,
+        constants: Vec<Constant>,
     ) -> ConstantResolver {
         debug!(target: "perf_events", "Building constant resolver");
-
-        // For each autoload path, do the following:
-        // 1) Glob for the ruby files
-        // 2) For each ruby file, remove the autoloaded portion of the path
-        // 3) For the remaining path, remove the .rb extension
-        // 4) For the remaining path, split it by "/"
-        // 5) Call packs::inflector::to_class_case on each element in the vector
-        // 6) Join the vector with ::
-        // 7) Strip the leading "::" from the string
-        // 8) Add the fully qualified constant name to the map, with the value being the absolute path of the file
-        debug!(target: "perf_events", "Get constant resolver cache");
-        let cache_data = get_constant_resolver_cache(cache_dir);
-
-        debug!(target: "perf_events", "Globbing out autoload paths");
-        // First, we get a map of each autoload path to the files they map to.
-        let autoload_paths_to_their_globbed_files = autoload_paths
-            .clone()
-            .into_iter()
-            .par_bridge()
-            .map(|absolute_autoload_path| {
-                let glob_path = absolute_autoload_path.join("**/*.rb");
-
-                let files = glob::glob(glob_path.to_str().unwrap())
-                    .expect("Failed to read glob pattern")
-                    .filter_map(Result::ok)
-                    .collect::<Vec<PathBuf>>();
-
-                (absolute_autoload_path, files)
-            })
-            .collect::<HashMap<PathBuf, Vec<PathBuf>>>();
-
-        debug!(target: "perf_events", "Finding autoload path for each file");
-        // Then, we want to know *which* autoload path is the one that defines a given constant.
-        // The longest autoload path should be the one that does this.
-        // For example, if we have two autoload paths:
-        // 1) packs/my_pack/app/models
-        // 2) packs/my_pack/app/models/concerns
-        // And we have a file at `packs/my_pack/app/models/concerns/foo.rb`, we want to say that the constant `Foo` is defined by the second autoload path.
-        // This is because the second autoload path is the longest path that contains the file.
-        // We do this by creating a map of each file to the longest autoload path that contains it.
-        let mut file_to_longest_path: HashMap<PathBuf, PathBuf> =
-            HashMap::new();
-
-        for (autoload_path, files) in &autoload_paths_to_their_globbed_files {
-            for file in files {
-                // Get the current longest path for this file, if it exists.
-                let current_longest_path = file_to_longest_path
-                    .entry(file.clone())
-                    .or_insert_with(|| autoload_path.clone());
-
-                // Update the longest path if the new path is longer.
-                if autoload_path.components().count()
-                    > current_longest_path.components().count()
-                {
-                    *current_longest_path = autoload_path.clone();
-                }
-            }
-        }
-
-        debug!(target: "perf_events", "Getting acronyms from disk");
-        let acronyms = &get_acronyms_from_disk(absolute_root);
-
-        debug!(target: "perf_events", "Inferring constants from file name (using cache)");
-        let constants: Vec<Constant> = file_to_longest_path
-            .into_iter()
-            .par_bridge()
-            .map(|(absolute_path_of_definition, absolute_autoload_path)| {
-                if let Some(fully_qualified_name) = cache_data
-                    .file_definition_map
-                    .get(&absolute_path_of_definition)
-                {
-                    Constant {
-                        fully_qualified_name: fully_qualified_name.to_owned(),
-                        absolute_path_of_definition,
-                    }
-                } else {
-                    inferred_constant_from_file(
-                        &absolute_path_of_definition,
-                        &absolute_autoload_path,
-                        acronyms,
-                    )
-                }
-            })
-            .collect::<Vec<Constant>>();
-
-        debug!(target: "perf_events", "Caching constant definitions");
-        cache_constant_definitions(&constants, cache_dir);
 
         debug!(target: "perf_events", "Building constant resolver from constants vector");
 
@@ -209,7 +58,6 @@ impl ConstantResolver {
 
         ConstantResolver {
             fully_qualified_constant_to_constant_map,
-            autoload_paths,
         }
     }
 
@@ -350,48 +198,6 @@ mod tests {
     use crate::packs::configuration;
 
     use super::*;
-
-    #[test]
-    fn test_file_map() {
-        let paths = vec![PathBuf::from(
-            "tests/fixtures/simple_app/packs/foo/app/services",
-        )];
-        let absolute_root = PathBuf::from("tests/fixtures/simple_app")
-            .canonicalize()
-            .expect("Could not canonicalize path");
-
-        let resolver = ConstantResolver::create(
-            &absolute_root,
-            paths,
-            &absolute_root.join("tmp/cache/packwerk"),
-        );
-
-        let mut expected_file_map: HashMap<String, Constant> = HashMap::new();
-        expected_file_map.insert(
-            "Foo".to_string(),
-            Constant {
-                fully_qualified_name: "Foo".to_string(),
-                absolute_path_of_definition: PathBuf::from(
-                    "tests/fixtures/simple_app/packs/foo/app/services/foo.rb",
-                ),
-            },
-        );
-
-        expected_file_map.insert(
-            "Foo::Bar".to_string(),
-            Constant {
-                fully_qualified_name: "Foo::Bar".to_string(),
-                absolute_path_of_definition: PathBuf::from(
-                    "tests/fixtures/simple_app/packs/foo/app/services/foo/bar.rb",
-                ),
-            }
-        );
-
-        let actual_file_map =
-            &resolver.fully_qualified_constant_to_constant_map;
-
-        assert_eq!(&expected_file_map, actual_file_map);
-    }
 
     #[test]
     fn unnested_reference_to_unnested_constant() {

--- a/src/packs/parsing/ruby/zeitwerk_utils.rs
+++ b/src/packs/parsing/ruby/zeitwerk_utils.rs
@@ -1,10 +1,77 @@
-use std::path::PathBuf;
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
 
+use rayon::prelude::{ParallelBridge, ParallelIterator};
+use serde::{Deserialize, Serialize};
 use tracing::debug;
 
-use crate::packs::{file_utils::process_glob_pattern, Pack};
+use crate::packs::{
+    file_utils::process_glob_pattern,
+    parsing::ruby::rails_utils::get_acronyms_from_disk, Pack, PackSet,
+};
 
-pub(crate) fn get_autoload_paths(packs: &Vec<Pack>) -> Vec<PathBuf> {
+use super::packwerk::constant_resolver::Constant;
+
+#[derive(Serialize, Deserialize)]
+struct ConstantResolverCache {
+    file_definition_map: HashMap<PathBuf, String>,
+}
+
+fn inferred_constant_from_file(
+    absolute_path: &Path,
+    absolute_autoload_path: &PathBuf,
+    acronyms: &HashSet<String>,
+) -> Constant {
+    let relative_path =
+        absolute_path.strip_prefix(absolute_autoload_path).unwrap();
+
+    let relative_path = relative_path.with_extension("");
+
+    let relative_path_str = relative_path.to_str().unwrap();
+    let fully_qualified_constant_name =
+        crate::packs::inflector_shim::camelize(relative_path_str, acronyms);
+
+    Constant {
+        fully_qualified_name: fully_qualified_constant_name,
+        absolute_path_of_definition: absolute_path.to_path_buf(),
+    }
+}
+
+fn get_constant_resolver_cache(cache_dir: &Path) -> ConstantResolverCache {
+    let path = cache_dir.join("constant_resolver.json");
+    if path.exists() {
+        let file = std::fs::File::open(path).unwrap();
+        let reader = std::io::BufReader::new(file);
+        serde_json::from_reader(reader).unwrap()
+    } else {
+        ConstantResolverCache {
+            file_definition_map: HashMap::new(),
+        }
+    }
+}
+
+fn cache_constant_definitions(constants: &Vec<Constant>, cache_dir: &Path) {
+    let mut file_definition_map: HashMap<PathBuf, String> = HashMap::new();
+    for constant in constants {
+        file_definition_map.insert(
+            constant.absolute_path_of_definition.clone(),
+            constant.fully_qualified_name.clone(),
+        );
+    }
+
+    let cache_data_json = serde_json::to_string(&ConstantResolverCache {
+        file_definition_map,
+    })
+    .expect("Failed to serialize");
+
+    std::fs::create_dir_all(cache_dir).unwrap();
+    std::fs::write(cache_dir.join("constant_resolver.json"), cache_data_json)
+        .unwrap();
+}
+
+fn get_autoload_paths(packs: &Vec<Pack>) -> Vec<PathBuf> {
     let mut autoload_paths: Vec<PathBuf> = Vec::new();
 
     debug!(
@@ -37,4 +104,150 @@ pub(crate) fn get_autoload_paths(packs: &Vec<Pack>) -> Vec<PathBuf> {
     );
 
     autoload_paths
+}
+
+pub fn inferred_constants_from_pack_set(
+    pack_set: &PackSet,
+    absolute_root: &Path,
+    cache_dir: &Path,
+) -> Vec<Constant> {
+    let autoload_paths = get_autoload_paths(&pack_set.packs);
+    inferred_constants_from_autoload_paths(
+        autoload_paths,
+        absolute_root,
+        cache_dir,
+    )
+}
+fn inferred_constants_from_autoload_paths(
+    autoload_paths: Vec<PathBuf>,
+    absolute_root: &Path,
+    cache_dir: &Path,
+) -> Vec<Constant> {
+    debug!(target: "perf_events", "Get constant resolver cache");
+    let cache_data = get_constant_resolver_cache(cache_dir);
+
+    debug!(target: "perf_events", "Globbing out autoload paths");
+    // First, we get a map of each autoload path to the files they map to.
+    let autoload_paths_to_their_globbed_files = autoload_paths
+        .into_iter()
+        .par_bridge()
+        .map(|absolute_autoload_path| {
+            let glob_path = absolute_autoload_path.join("**/*.rb");
+
+            let files = glob::glob(glob_path.to_str().unwrap())
+                .expect("Failed to read glob pattern")
+                .filter_map(Result::ok)
+                .collect::<Vec<PathBuf>>();
+
+            (absolute_autoload_path, files)
+        })
+        .collect::<HashMap<PathBuf, Vec<PathBuf>>>();
+
+    debug!(target: "perf_events", "Finding autoload path for each file");
+    // Then, we want to know *which* autoload path is the one that defines a given constant.
+    // The longest autoload path should be the one that does this.
+    // For example, if we have two autoload paths:
+    // 1) packs/my_pack/app/models
+    // 2) packs/my_pack/app/models/concerns
+    // And we have a file at `packs/my_pack/app/models/concerns/foo.rb`, we want to say that the constant `Foo` is defined by the second autoload path.
+    // This is because the second autoload path is the longest path that contains the file.
+    // We do this by creating a map of each file to the longest autoload path that contains it.
+    let mut file_to_longest_path: HashMap<PathBuf, PathBuf> = HashMap::new();
+
+    for (autoload_path, files) in &autoload_paths_to_their_globbed_files {
+        for file in files {
+            // Get the current longest path for this file, if it exists.
+            let current_longest_path = file_to_longest_path
+                .entry(file.clone())
+                .or_insert_with(|| autoload_path.clone());
+
+            // Update the longest path if the new path is longer.
+            if autoload_path.components().count()
+                > current_longest_path.components().count()
+            {
+                *current_longest_path = autoload_path.clone();
+            }
+        }
+    }
+
+    debug!(target: "perf_events", "Getting acronyms from disk");
+    let acronyms = &get_acronyms_from_disk(absolute_root);
+
+    debug!(target: "perf_events", "Inferring constants from file name (using cache)");
+    let constants: Vec<Constant> = file_to_longest_path
+        .into_iter()
+        .par_bridge()
+        .map(|(absolute_path_of_definition, absolute_autoload_path)| {
+            if let Some(fully_qualified_name) = cache_data
+                .file_definition_map
+                .get(&absolute_path_of_definition)
+            {
+                Constant {
+                    fully_qualified_name: fully_qualified_name.to_owned(),
+                    absolute_path_of_definition,
+                }
+            } else {
+                inferred_constant_from_file(
+                    &absolute_path_of_definition,
+                    &absolute_autoload_path,
+                    acronyms,
+                )
+            }
+        })
+        .collect::<Vec<Constant>>();
+
+    debug!(target: "perf_events", "Caching constant definitions");
+    cache_constant_definitions(&constants, cache_dir);
+
+    constants
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::packs::parsing::ruby::packwerk::constant_resolver::{
+        Constant, ConstantResolver,
+    };
+    #[test]
+    fn test_file_map() {
+        let paths = vec![PathBuf::from(
+            "tests/fixtures/simple_app/packs/foo/app/services",
+        )];
+        let absolute_root = PathBuf::from("tests/fixtures/simple_app")
+            .canonicalize()
+            .expect("Could not canonicalize path");
+
+        let constants = inferred_constants_from_autoload_paths(
+            paths,
+            &absolute_root,
+            &absolute_root.join("tmp/cache/packwerk"),
+        );
+        let resolver = ConstantResolver::create(&absolute_root, constants);
+
+        let mut expected_file_map: HashMap<String, Constant> = HashMap::new();
+        expected_file_map.insert(
+            "Foo".to_string(),
+            Constant {
+                fully_qualified_name: "Foo".to_string(),
+                absolute_path_of_definition: PathBuf::from(
+                    "tests/fixtures/simple_app/packs/foo/app/services/foo.rb",
+                ),
+            },
+        );
+
+        expected_file_map.insert(
+        "Foo::Bar".to_string(),
+        Constant {
+            fully_qualified_name: "Foo::Bar".to_string(),
+            absolute_path_of_definition: PathBuf::from(
+                "tests/fixtures/simple_app/packs/foo/app/services/foo/bar.rb",
+            ),
+        },
+    );
+
+        let actual_file_map =
+            &resolver.fully_qualified_constant_to_constant_map;
+
+        assert_eq!(&expected_file_map, actual_file_map);
+    }
 }


### PR DESCRIPTION
This gets us ready to allow a constant resolver to be more easily initialized from a set of processed files for the alternate parser.