### PR TITLE
Improve logging with --debug flag 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rayon = "1.7.0" # for parallel iteration
 regex = "1.7.3"
 serde = { version = "~1", features = ["derive"] } # de(serialization)
 serde_yaml = "0.9.19"
-tracing = "0.1.37" # observability tooling, may not be necessary!
+tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 glob = "0.3.1"
 lib-ruby-parser = "4.0.4"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Commands:
 
 Options:
       --project-root <PROJECT_ROOT>  Path for the root of the project [default: .]
+  -d, --debug                        Run with debug mode
   -h, --help                         Print help
   -V, --version                      Print version
 ```

--- a/dev/notes.md
+++ b/dev/notes.md
@@ -33,7 +33,7 @@ For more, see: https://nnethercote.github.io/perf-book/profiling.html
 # Local Development
 ## Running the CLI in release mode against a target app
 ```
-RUST_LOG=perf_events=debug time cargo run --profile=release -- --project-root=../your_app check
+time cargo run --profile=release -- --debug --project-root=../your_app check
 ```
 
 # Packwerk Implementation Considerations

--- a/src/main-alt.rs
+++ b/src/main-alt.rs
@@ -1,7 +1,5 @@
 use packs::packs::cli;
-use packs::packs::logger::install_logger;
 
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
-    install_logger();
     cli::run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 use packs::packs::cli;
-use packs::packs::logger::install_logger;
 
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
-    install_logger();
     cli::run()
 }

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -149,29 +149,20 @@ pub(crate) fn check(
         cache_dir: configuration.cache_directory.to_owned(),
     };
 
-    debug!(
-        target: "perf_events",
-        "Interecting input files with configuration included files"
-    );
+    debug!("Interecting input files with configuration included files");
     let absolute_paths: HashSet<PathBuf> = configuration.intersect_files(files);
 
     let violations: Vec<Violation> =
         get_all_violations(&configuration, absolute_paths, cache);
     let recorded_violations = configuration.pack_set.all_violations;
 
-    debug!(
-        target: "perf_events",
-        "Filtering out recorded violations"
-    );
+    debug!("Filtering out recorded violations");
     let unrecorded_violations = violations
         .iter()
         .filter(|v| !recorded_violations.contains(&v.identifier))
         .collect::<Vec<&Violation>>();
 
-    debug!(
-        target: "perf_events",
-        "Finished filtering out recorded violations"
-    );
+    debug!("Finished filtering out recorded violations");
 
     if !unrecorded_violations.is_empty() {
         for violation in unrecorded_violations.iter() {
@@ -212,10 +203,7 @@ fn get_all_violations<T: Cache + Send + Sync>(
     // TODO: Write a test that if this isn't here, it fails gracefully
     create_cache_dir_idempotently(&configuration.cache_directory);
 
-    debug!(
-        target: "perf_events",
-        "Getting unresolved references (using cache if possible)"
-    );
+    debug!("Getting unresolved references (using cache if possible)");
     let processed_files: Vec<ProcessedFile> = process_files_with_cache(
         &configuration.absolute_root,
         &absolute_paths,
@@ -228,10 +216,7 @@ fn get_all_violations<T: Cache + Send + Sync>(
         &configuration.cache_directory,
     );
 
-    debug!(
-        target: "perf_events",
-        "Turning unresolved references into fully qualified references"
-    );
+    debug!("Turning unresolved references into fully qualified references");
     let references: Vec<Reference> = processed_files
         .into_par_iter()
         .flat_map(|processed_file| {
@@ -253,12 +238,9 @@ fn get_all_violations<T: Cache + Send + Sync>(
             references
         })
         .collect();
-    debug!(target: "perf_events", "Finished turning unresolved references into fully qualified references");
+    debug!("Finished turning unresolved references into fully qualified references");
 
-    debug!(
-        target: "perf_events",
-        "Running checkers on resolved references"
-    );
+    debug!("Running checkers on resolved references");
     let checkers: Vec<Box<dyn CheckerInterface + Send + Sync>> = vec![
         Box::new(dependency::Checker {}),
         Box::new(privacy::Checker {}),
@@ -276,7 +258,7 @@ fn get_all_violations<T: Cache + Send + Sync>(
                 .collect::<Vec<Violation>>()
         })
         .collect();
-    debug!(target: "perf_events", "Finished running checkers");
+    debug!("Finished running checkers");
 
     violations
 }

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -3,6 +3,7 @@ use crate::packs::checker;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+use super::logger::install_logger;
 use super::parsing::ruby::zeitwerk_utils::get_zeitwerk_constant_resolver;
 
 #[derive(Subcommand, Debug)]
@@ -52,6 +53,10 @@ struct Args {
     /// Path for the root of the project
     #[arg(long, default_value = ".")]
     project_root: PathBuf,
+
+    /// Run with performance debug mode
+    #[arg(short, long)]
+    debug: bool,
 }
 
 impl Args {
@@ -65,6 +70,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
     let absolute_root = args
         .absolute_project_root()
         .expect("Issue getting absolute_project_root!");
+    install_logger(args.debug);
 
     let configuration = packs::configuration::get(&absolute_root);
 

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -70,6 +70,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
     let absolute_root = args
         .absolute_project_root()
         .expect("Issue getting absolute_project_root!");
+
     install_logger(args.debug);
 
     let configuration = packs::configuration::get(&absolute_root);
@@ -98,6 +99,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
         Command::ListDefinitions => {
+            panic!("This command is not yet implemented");
             // TODO: This and other commands that fetch the constant resolver
             // Should respect the configuration flag.
             let constant_resolver = get_zeitwerk_constant_resolver(

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -45,10 +45,7 @@ impl Configuration {
 }
 
 pub(crate) fn get(absolute_root: &Path) -> Configuration {
-    debug!(
-        target: "perf_events",
-        "Beginning to build configuration"
-    );
+    debug!("Beginning to build configuration");
 
     let raw_config = raw_configuration::get(absolute_root);
 
@@ -67,10 +64,7 @@ pub(crate) fn get(absolute_root: &Path) -> Configuration {
         layers: raw_config.architecture_layers,
     };
 
-    debug!(
-        target: "perf_events",
-        "Finished building configuration"
-    );
+    debug!("Finished building configuration");
 
     Configuration {
         included_files,

--- a/src/packs/logger.rs
+++ b/src/packs/logger.rs
@@ -30,6 +30,13 @@ pub fn install_logger(debug: bool) {
         .with_line_number(true);
 
     if debug {
+        // If debug mode is on, let's always show the full backtrace,
+        // which helps make debugging panic messages simpler.
+        // There may be a more standard way to do this than setting the backtrace,
+        // but it works for now.
+        std::env::set_var("RUST_BACKTRACE", "full");
+
+        // Let's also set the log level to be debug with this flag.
         let subscriber_builder =
             subscriber_builder.with_max_level(Level::DEBUG);
         let subscriber = subscriber_builder.finish();

--- a/src/packs/logger.rs
+++ b/src/packs/logger.rs
@@ -1,19 +1,43 @@
+use tracing::metadata::LevelFilter;
+use tracing::Level;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::prelude::*;
+
 //
 // This allows us to run the binary with timing and debug output, like so:
-// $ RUST_LOG=debug ../packs-rs/target/release/packs update
-//    0.001426500s DEBUG packs::packs::configuration: src/packs/configuration.rs:263: Beginning to read configuration
-//    0.843766458s DEBUG packs::packs::configuration: src/packs/configuration.rs:308: Finished reading configuration
-//    0.845547750s DEBUG packs::packs::cache: src/packs/cache.rs:243: Writing cache for 29078 files
-//    1.855275708s DEBUG packs::packs::cache: src/packs/cache.rs:252: Finished writing cache for 29078 files
+// $ packs --debug update
+//    0.000116875s DEBUG src/packs/configuration.rs:52: Beginning to build configuration
+//    0.000253917s DEBUG src/packs/walk_directory.rs:24: Beginning directory walk
+//    0.014609292s DEBUG src/packs/walk_directory.rs:144: Finished directory walk
+//    ...
+//    0.072214542s DEBUG src/packs/checker.rs:159: Filtering out recorded violations
+//    0.072355292s DEBUG src/packs/checker.rs:168: Finished filtering out recorded violations
 //
-pub fn install_logger() {
-    tracing_subscriber::fmt()
+pub fn install_logger(debug: bool) {
+    let filter = tracing_subscriber::filter::Targets::new()
+        .with_default(LevelFilter::DEBUG)
+        // Disable all traces from `globset`.
+        .with_target("globset", LevelFilter::OFF);
+
+    let subscriber_builder = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .with_target(true)
+        .with_target(false)
         .with_timer(tracing_subscriber::fmt::time::uptime())
         .with_level(true)
         .with_writer(std::io::stderr)
         .with_file(true)
-        .with_line_number(true)
-        .init();
+        .with_span_events(FmtSpan::ACTIVE)
+        .with_line_number(true);
+
+    if debug {
+        let subscriber_builder =
+            subscriber_builder.with_max_level(Level::DEBUG);
+        let subscriber = subscriber_builder.finish();
+        let layered_subscriber = filter.with_subscriber(subscriber);
+        layered_subscriber.init();
+    } else {
+        let subscriber = subscriber_builder.finish();
+        let layered_subscriber = filter.with_subscriber(subscriber);
+        layered_subscriber.init();
+    }
 }

--- a/src/packs/package_todo.rs
+++ b/src/packs/package_todo.rs
@@ -133,10 +133,7 @@ pub fn write_violations_to_disk(
     configuration: Configuration,
     violations: Vec<Violation>,
 ) {
-    debug!(
-        target: "perf_events",
-        "Starting writing violations to disk"
-    );
+    debug!("Starting writing violations to disk");
     // First we need to group the violations by the repsonsible pack, which today is always the referencing pack
     // Later if we change where a violation shows up, we should delegate to the checker
     // to decide what pack it should be in.
@@ -162,10 +159,7 @@ pub fn write_violations_to_disk(
         );
     }
 
-    debug!(
-        target: "perf_events",
-        "Finished writing violations to disk"
-    );
+    debug!("Finished writing violations to disk");
 }
 
 fn serialize_package_todo(

--- a/src/packs/parsing/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parsing/ruby/packwerk/constant_resolver.rs
@@ -23,9 +23,9 @@ impl ConstantResolver {
         absolute_root: &Path,
         constants: Vec<Constant>,
     ) -> ConstantResolver {
-        debug!(target: "perf_events", "Building constant resolver");
+        debug!("Building constant resolver");
 
-        debug!(target: "perf_events", "Building constant resolver from constants vector");
+        debug!("Building constant resolver from constants vector");
 
         let mut fully_qualified_constant_to_constant_map: HashMap<
             String,
@@ -51,10 +51,7 @@ impl ConstantResolver {
             }
         }
 
-        debug!(
-            target: "perf_events",
-            "Finished building constant resolver"
-        );
+        debug!("Finished building constant resolver");
 
         ConstantResolver {
             fully_qualified_constant_to_constant_map,

--- a/src/packs/parsing/ruby/zeitwerk_utils.rs
+++ b/src/packs/parsing/ruby/zeitwerk_utils.rs
@@ -42,10 +42,10 @@ fn inferred_constants_from_autoload_paths(
     absolute_root: &Path,
     cache_dir: &Path,
 ) -> Vec<Constant> {
-    debug!(target: "perf_events", "Get constant resolver cache");
+    debug!("Get constant resolver cache");
     let cache_data = get_constant_resolver_cache(cache_dir);
 
-    debug!(target: "perf_events", "Globbing out autoload paths");
+    debug!("Globbing out autoload paths");
     // First, we get a map of each autoload path to the files they map to.
     let autoload_paths_to_their_globbed_files = autoload_paths
         .into_iter()
@@ -62,7 +62,7 @@ fn inferred_constants_from_autoload_paths(
         })
         .collect::<HashMap<PathBuf, Vec<PathBuf>>>();
 
-    debug!(target: "perf_events", "Finding autoload path for each file");
+    debug!("Finding autoload path for each file");
     // Then, we want to know *which* autoload path is the one that defines a given constant.
     // The longest autoload path should be the one that does this.
     // For example, if we have two autoload paths:
@@ -89,10 +89,10 @@ fn inferred_constants_from_autoload_paths(
         }
     }
 
-    debug!(target: "perf_events", "Getting acronyms from disk");
+    debug!("Getting acronyms from disk");
     let acronyms = &get_acronyms_from_disk(absolute_root);
 
-    debug!(target: "perf_events", "Inferring constants from file name (using cache)");
+    debug!("Inferring constants from file name (using cache)");
     let constants: Vec<Constant> = file_to_longest_path
         .into_iter()
         .par_bridge()
@@ -115,7 +115,7 @@ fn inferred_constants_from_autoload_paths(
         })
         .collect::<Vec<Constant>>();
 
-    debug!(target: "perf_events", "Caching constant definitions");
+    debug!("Caching constant definitions");
     cache_constant_definitions(&constants, cache_dir);
 
     constants
@@ -181,10 +181,7 @@ fn cache_constant_definitions(constants: &Vec<Constant>, cache_dir: &Path) {
 fn get_autoload_paths(packs: &Vec<Pack>) -> Vec<PathBuf> {
     let mut autoload_paths: Vec<PathBuf> = Vec::new();
 
-    debug!(
-        target: "perf_events",
-        "Getting autoload paths"
-    );
+    debug!("Getting autoload paths");
 
     for pack in packs {
         // App paths
@@ -205,10 +202,7 @@ fn get_autoload_paths(packs: &Vec<Pack>) -> Vec<PathBuf> {
         process_glob_pattern(concerns_glob_pattern, &mut autoload_paths);
     }
 
-    debug!(
-        target: "perf_events",
-        "Finished getting autoload paths"
-    );
+    debug!("Finished getting autoload paths");
 
     autoload_paths
 }

--- a/src/packs/walk_directory.rs
+++ b/src/packs/walk_directory.rs
@@ -21,7 +21,7 @@ pub(crate) fn walk_directory(
     absolute_root: PathBuf,
     raw: &RawConfiguration,
 ) -> WalkDirectoryResult {
-    debug!(target: "perf_events", "Beginning directory walk");
+    debug!("Beginning directory walk");
 
     let mut included_files: HashSet<PathBuf> = HashSet::new();
     let mut included_packs: HashSet<Pack> = HashSet::new();
@@ -141,7 +141,7 @@ pub(crate) fn walk_directory(
         }
     }
 
-    debug!(target: "perf_events", "Finished directory walk");
+    debug!("Finished directory walk");
 
     WalkDirectoryResult {
         included_files,


### PR DESCRIPTION
This allows the CLI to be run with `packs --debug check`, which makes debugging where time is spent simpler.