### PR TITLE
Spike on experimental parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.38"
+version = "0.1.39"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/EXPERIMENTAL_PARSER_USAGE.md
+++ b/EXPERIMENTAL_PARSER_USAGE.md
@@ -1,5 +1,12 @@
 # Experimental Parser Usage
 
+TLDR:
+- `packs --experimental-parser update` and `packs --experimental-parser check` OR use `experimental_parser: true` in your `packwerk.yml`.
+- When switching between the `experimental` and `packwerk` parser, run `packs delete-cache` – the two caches are not compatible!
+- `packwerk` infers constant definitions based on file names
+- The `experimental` parser explicitly parses constant definitions from files
+- There are some limitations still that might produce unexpected behavior. Please share your feedback!
+
 ## What's the difference?
 First, some context:
 - Packs builds a graph of each package, the files within those packages, the constants (i.e. class, modules, or CONSTANTS) referenced within those files, and the constants defined within those files.

--- a/EXPERIMENTAL_PARSER_USAGE.md
+++ b/EXPERIMENTAL_PARSER_USAGE.md
@@ -1,0 +1,29 @@
+# Experimental Parser Usage
+
+## What's the difference?
+First, some context:
+- Packs builds a graph of each package, the files within those packages, the constants (i.e. class, modules, or CONSTANTS) referenced within those files, and the constants defined within those files.
+- The *packwerk* parser will parse files for references, but it has some quirks:
+  - A *definition* counts as a reference. So `class Foo::Bar; end` is a reference to both "Foo" and "Foo::Bar". This means that if `Foo` is defined in another pack, it might show up as a violation.
+  - Packwerk uses zeitwerk conventions (hence the name) to infer file definitions. So for example, `foo/bar.rb` defines `Foo::Bar`. It uses various Rails conventions (autoload paths, inflections, etc.) to infer what constants a path defines.
+  - As a result of this, it has some limitations:
+    - It cannot be used in non-Rails apps, or Rails apps that do not follow zeitwerk conventions (meaning it can't parse non-autoloaded code).
+    - A file can only be considered to define exactly one constant, which is the constant that matches the file name.
+- The *experimental* parser, in contrast, works as follows:
+  - A reference is parsed just like it is with the `packwerk` parser, except definitions do not count as references.
+  - Definitions are parsed directly from the file, rather than inferring them from file names.
+  - We could consider `module Foo; class Bar; end; end` to define both `Foo` and `Foo::Bar`, since it opens up `Foo`. The approach the experimental parser takes is that any file defines a constant if it changes behavior within that constant. So for example, `module Foo; class Bar; end; end` actually defines nothing (since it does not change behavior). `module Foo; class Bar; def bar; end; end; end;` defines `Foo::Bar` (since it changes behavior within `Foo::Bar`), and `module Foo; def foo; end; class Bar; def bar; end; end; end;` defines both `Foo` and `Foo::Bar` (since it changes behavior within both).
+
+## Usage Notes
+- See usage with `packs --help`:
+  - TLDR `packs -e update` and `packs -e check` OR use `experimental_parser: true` in your `packwerk.yml`.
+- This is experimental API that could change!
+- While the cache formats for the two parsers are the same, the packwerk resolver always caches an empty list of definitions. To switch between the two parsers and have expected results, you must clear the cache. You can do this with `packs delete-cache`.
+- If you're unclear where `packs` thinks a constant is defined, you can use `packs -e list-definitions`
+
+# Upcoming Developments + Limitations
+- Over time, we'll want to refine how we handle monkey patches. Alternative implementations are:
+  - We could consider *every* time a constant is opened up (i.e. a `class` or `module` keyword) to be "defining" a constant. This would mean that tons of files define the same constants. This is not a problem unless *different packs* define the same constant. This implementation would be very strict against monkey patches.
+  - We could allow a monkey patch to be defined within `packwerk.yml`, so that it can be ignored as a definition. For example, if the root pack opens up `String`, we might have `String: config/initializers/string_extensions.rb` in our `packwerk.yml`.
+- Right now, if multiple files define the same constant, we just choose the *first* one. This is not an ideal implementation at all. Instead, we should think about having constants be able to be defined by multiple files. Instead of having a "primary" definition, we can create one reference for each definition. For example, if `packs/a` and `packs/b` define `Foo`, then using `Foo` creates one reference to each of those packs.
+

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Commands:
 
 Options:
       --project-root <PROJECT_ROOT>  Path for the root of the project [default: .]
-  -d, --debug                        Run with debug mode
+  -d, --debug                        Run with performance debug mode
+  -e, --experimental-parser          Run with the experimental parser, which gets constant definitions directly from the AST
+      --no-cache                     Run without the cache (good for CI, testing)
   -h, --help                         Print help
   -V, --version                      Print version
 ```

--- a/dev/notes.md
+++ b/dev/notes.md
@@ -1,8 +1,5 @@
 # TODO
 
-## Refactors
-- do not use cache anywhere in tests
-
 ## Features
 - Explore alternate extractor (below)
 - Implement cycle detection within check command, see https://docs.rs/petgraph/latest/petgraph/algo/index.html

--- a/dev/notes.md
+++ b/dev/notes.md
@@ -1,7 +1,8 @@
 # TODO
 
 ## Features
-- Explore alternate extractor (below)
+- Refactor common methods from experimental and packwerk parsers
+- Think through how to handle monkey patches / opening up other modules in experimental parser
 - Implement cycle detection within check command, see https://docs.rs/petgraph/latest/petgraph/algo/index.html
 
 ## Performance
@@ -38,10 +39,10 @@ time cargo run --profile=release -- --debug --project-root=../your_app check
 ```
 
 # Packwerk Implementation Considerations
+- See `EXPERIMENTAL_PARSER_USAGE.md` for more info
 - Packwerk considers a definition to be a reference. I explored removing this in this branch: https://github.com/alexevanczuk/packs/pull/44
   - This results in a diff in violations, because if a class opens up a module defined by another class, its considered to be a reference to that other class.
   - I think this is actually a bug in packwerk, since a definition is not really a reference. Even though monkey patching / opening up other moduels is not great, we should surface that information through a different mechanism (such as allowing packs to have a monkey patches violation)
-  - Note this logic can be moved into the experimental parser, since it does not need to preserve behavior.
 
 # Abandoned Performance Improvement Attempts
 - In https://github.com/alexevanczuk/packs/pull/37, I looked into getting the constants *as* we are walking the directory. However, I found that this was hardly much more performant than the current implementation, and it was much more complex. I abandoned this approach in favor of caching the resolver and other performance improvements.
@@ -50,16 +51,3 @@ time cargo run --profile=release -- --debug --project-root=../your_app check
 Today, `packwerk` has a modular architecture allowing folks to add new checkers, validators, etc.
 Eventually, I'd like to port this idea over to `packs`.
 We might consider how we can have specific checkers/validators be responsible for their own portion of the deserialized properties in `package.yml` files.
-
-# Alternate Extractor
-The alternate extractor is an experimental implementation of the extractor that does not infer constants from file names, but instead parses them directly.
-
-## Implementation Notes:
-- Allow it to be configured with cmd line argument, e.g. `--extractor=experimental` or packwerk.yml flag
-- This feature should have a "monkeypatches" key in packwerk.yml. This is a hash of constants and what file monkey patches them. "Validate" should check this. This can allow the alternate implementation to avoid violations on a monkey patched "String" class, for example.
-- This parser thinks a constant can be defined in many places. For each place, it establishes one reference.
-- This parser does not consider definitions to be references. (This is a bug in the current implementation – see above.)
-
-## Sequencing
-- Implement
-- Announce it, share learnings, and demo it at guild meeting

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -27,6 +27,7 @@ pub use crate::packs::pack_set::PackSet;
 use crate::packs::parsing::process_files_with_cache;
 use crate::packs::parsing::ruby::experimental::get_experimental_constant_resolver;
 use crate::packs::parsing::ruby::zeitwerk_utils::get_zeitwerk_constant_resolver;
+use crate::packs::per_file_cache::create_cache_dir_idempotently;
 pub use configuration::Configuration;
 pub use package_todo::PackageTodo;
 
@@ -276,6 +277,9 @@ impl Pack {
 }
 
 pub(crate) fn list_definitions(configuration: &Configuration) {
+    // TODO: Write a test that if this isn't here, it fails gracefully
+    create_cache_dir_idempotently(&configuration.cache_directory);
+
     let constant_resolver = if configuration.experimental_parser {
         let processed_files: Vec<ProcessedFile> = process_files_with_cache(
             &configuration.absolute_root,

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -24,11 +24,14 @@ mod walk_directory;
 // Re-exports: Eventually, these may be part of the public API for packs
 pub use crate::packs::checker::Violation;
 pub use crate::packs::pack_set::PackSet;
+use crate::packs::parsing::process_files_with_cache;
+use crate::packs::parsing::ruby::experimental::get_experimental_constant_resolver;
+use crate::packs::parsing::ruby::zeitwerk_utils::get_zeitwerk_constant_resolver;
 pub use configuration::Configuration;
 pub use package_todo::PackageTodo;
 
 use self::checker::ViolationIdentifier;
-use self::parsing::ruby::packwerk::constant_resolver::ConstantResolver;
+
 use self::parsing::Definition;
 use self::parsing::UnresolvedReference;
 
@@ -272,7 +275,28 @@ impl Pack {
     }
 }
 
-pub(crate) fn list_definitions(constant_resolver: &ConstantResolver) {
+pub(crate) fn list_definitions(configuration: &Configuration) {
+    let constant_resolver = if configuration.experimental_parser {
+        let processed_files: Vec<ProcessedFile> = process_files_with_cache(
+            &configuration.absolute_root,
+            &configuration.included_files,
+            configuration.get_cache(),
+            true,
+        );
+
+        get_experimental_constant_resolver(
+            &configuration.absolute_root,
+            &processed_files,
+        )
+    } else {
+        get_zeitwerk_constant_resolver(
+            &configuration.pack_set,
+            &configuration.absolute_root,
+            &configuration.cache_directory,
+            !configuration.cache_enabled,
+        )
+    };
+
     dbg!(&constant_resolver.fully_qualified_constant_to_constant_map);
 }
 

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -64,7 +64,7 @@ pub struct ProcessedFile {
     pub definitions: Vec<Definition>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Default, Eq)]
 pub struct SourceLocation {
     line: usize,
     column: usize,
@@ -301,7 +301,20 @@ pub(crate) fn list_definitions(configuration: &Configuration) {
         )
     };
 
-    dbg!(&constant_resolver.fully_qualified_constant_to_constant_map);
+    let constants = constant_resolver
+        .fully_qualified_constant_to_constant_map
+        .values();
+
+    for constant in constants {
+        let relative_path = constant
+            .absolute_path_of_definition
+            .strip_prefix(&configuration.absolute_root)
+            .unwrap();
+        println!(
+            "{:?} is defined at {:?}",
+            constant.fully_qualified_name, relative_path
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -251,8 +251,6 @@ fn get_all_violations(
         })
         .collect();
 
-    dbg!(&references);
-
     debug!("Finished turning unresolved references into fully qualified references");
 
     debug!("Running checkers on resolved references");

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -1,5 +1,6 @@
 use crate::packs::package_todo;
 use crate::packs::parsing::process_files_with_cache;
+use crate::packs::parsing::ruby::experimental::get_experimental_constant_resolver;
 use crate::packs::parsing::ruby::zeitwerk_utils::get_zeitwerk_constant_resolver;
 
 use crate::packs::per_file_cache::create_cache_dir_idempotently;
@@ -213,12 +214,21 @@ fn get_all_violations(
         experimental_parser,
     );
 
-    let constant_resolver = get_zeitwerk_constant_resolver(
-        &configuration.pack_set,
-        &configuration.absolute_root,
-        &configuration.cache_directory,
-        !configuration.cache_enabled,
-    );
+    let constant_resolver = if configuration.experimental_parser {
+        get_experimental_constant_resolver(
+            &configuration.absolute_root,
+            &processed_files,
+        )
+    } else {
+        get_zeitwerk_constant_resolver(
+            &configuration.pack_set,
+            &configuration.absolute_root,
+            &configuration.cache_directory,
+            !configuration.cache_enabled,
+        )
+    };
+
+    dbg!(&constant_resolver.fully_qualified_constant_to_constant_map);
 
     debug!("Turning unresolved references into fully qualified references");
     let references: Vec<Reference> = processed_files
@@ -242,6 +252,9 @@ fn get_all_violations(
             references
         })
         .collect();
+
+    dbg!(&references);
+
     debug!("Finished turning unresolved references into fully qualified references");
 
     debug!("Running checkers on resolved references");
@@ -262,6 +275,7 @@ fn get_all_violations(
                 .collect::<Vec<Violation>>()
         })
         .collect();
+
     debug!("Finished running checkers");
 
     violations

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -228,8 +228,6 @@ fn get_all_violations(
         )
     };
 
-    dbg!(&constant_resolver.fully_qualified_constant_to_constant_map);
-
     debug!("Turning unresolved references into fully qualified references");
     let references: Vec<Reference> = processed_files
         .into_par_iter()

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use tracing::debug;
 
 use super::logger::install_logger;
-use super::parsing::ruby::zeitwerk_utils::get_zeitwerk_constant_resolver;
+
 use super::Configuration;
 
 #[derive(Subcommand, Debug)]
@@ -122,18 +122,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
         Command::ListDefinitions => {
-            let constant_resolver = if configuration.experimental_parser {
-                panic!("List definitions is not yet supported with the experimental parser")
-            } else {
-                get_zeitwerk_constant_resolver(
-                    &configuration.pack_set,
-                    &configuration.absolute_root,
-                    &configuration.cache_directory,
-                    !configuration.cache_enabled,
-                )
-            };
-
-            packs::list_definitions(&constant_resolver);
+            packs::list_definitions(&configuration);
             Ok(())
         }
     }

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -86,9 +86,8 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut configuration = packs::configuration::get(&absolute_root);
 
     if args.experimental_parser {
-        // debug!("Using experimental parser");
-        // configuration = configuration.with_experimental_parser();
-        panic!("The experimental parser is coming soon!")
+        debug!("Using experimental parser");
+        configuration = configuration.with_experimental_parser();
     }
 
     if args.no_cache {
@@ -124,7 +123,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         Command::ListDefinitions => {
             let constant_resolver = if configuration.experimental_parser {
-                panic!("The experimental parser is coming soon!")
+                panic!("List definitions is not yet supported with the experimental parser")
             } else {
                 get_zeitwerk_constant_resolver(
                     &configuration.pack_set,

--- a/src/packs/file_utils.rs
+++ b/src/packs/file_utils.rs
@@ -1,5 +1,7 @@
 use std::{
     collections::HashSet,
+    fs,
+    io::Read,
     path::{Path, PathBuf},
 };
 
@@ -98,4 +100,18 @@ pub(crate) fn convert_erb_to_ruby_without_sourcemaps(
         .collect();
 
     extracted_contents.join("\n")
+}
+
+pub(crate) fn file_content_digest(file: &Path) -> String {
+    let mut file_content = Vec::new();
+
+    // Read the file content
+    let mut file_handle = fs::File::open(file)
+        .unwrap_or_else(|_| panic!("Failed to open file {:?}", file));
+    file_handle
+        .read_to_end(&mut file_content)
+        .expect("Failed to read file");
+
+    // Compute the MD5 digest
+    format!("{:x}", md5::compute(&file_content))
 }

--- a/src/packs/parsing.rs
+++ b/src/packs/parsing.rs
@@ -4,8 +4,10 @@ use std::{
 };
 
 pub(crate) mod ruby;
+pub(crate) use ruby::experimental::parser::process_from_path as process_from_ruby_path_experimental;
 pub(crate) use ruby::packwerk::parser::process_from_path as process_from_ruby_path;
 pub(crate) mod erb;
+pub(crate) use erb::experimental::parser::process_from_path as process_from_erb_path_experimental;
 pub(crate) use erb::packwerk::parser::process_from_path as process_from_erb_path;
 
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
@@ -23,14 +25,14 @@ pub fn process_file(path: &Path, experimental_parser: bool) -> ProcessedFile {
         match file_type {
             SupportedFileType::Ruby => {
                 if experimental_parser {
-                    panic!("The experimental parser is coming soon!")
+                    process_from_ruby_path_experimental(path)
                 } else {
                     process_from_ruby_path(path)
                 }
             }
             SupportedFileType::Erb => {
                 if experimental_parser {
-                    panic!("The experimental parser is coming soon!")
+                    process_from_erb_path_experimental(path)
                 } else {
                     process_from_erb_path(path)
                 }

--- a/src/packs/parsing/erb/experimental.rs
+++ b/src/packs/parsing/erb/experimental.rs
@@ -1,0 +1,1 @@
+pub(crate) mod parser;

--- a/src/packs/parsing/erb/experimental/parser.rs
+++ b/src/packs/parsing/erb/experimental/parser.rs
@@ -1,0 +1,41 @@
+use crate::packs::{
+    file_utils::convert_erb_to_ruby_without_sourcemaps, parsing::Range,
+    ProcessedFile, UnresolvedReference,
+};
+use std::{fs, path::Path};
+
+use crate::packs::parsing::ruby::experimental::parser::process_from_contents as process_from_ruby_contents;
+
+pub(crate) fn process_from_path(path: &Path) -> ProcessedFile {
+    let contents = fs::read_to_string(path).unwrap_or_else(|_| {
+        panic!("Failed to read contents of {}", path.to_string_lossy())
+    });
+
+    process_from_contents(contents, path)
+}
+
+pub(crate) fn process_from_contents(
+    contents: String,
+    path: &Path,
+) -> ProcessedFile {
+    let ruby_contents = convert_erb_to_ruby_without_sourcemaps(contents);
+    let processed_file = process_from_ruby_contents(ruby_contents, path);
+    let references = processed_file.unresolved_references;
+    // let references_without_range = references
+    let references_without_range = references
+        .iter()
+        .map(|r| UnresolvedReference {
+            // Source maps are not yet supported for ERB, since we just turn it into Ruby code
+            // that doesn't necessarily map up to the original.
+            // We need to add extra logic to support source maps (or use a proper parsing library).
+            location: Range::default(),
+            ..r.clone()
+        })
+        .collect();
+
+    ProcessedFile {
+        absolute_path: path.to_path_buf(),
+        unresolved_references: references_without_range,
+        definitions: vec![],
+    }
+}

--- a/src/packs/parsing/erb/mod.rs
+++ b/src/packs/parsing/erb/mod.rs
@@ -1,1 +1,2 @@
+pub mod experimental;
 pub mod packwerk;

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -5,7 +5,7 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::packs::parsing::ruby::experimental::parser::process_from_contents;
-    use crate::packs::parsing::Range;
+    use crate::packs::parsing::{Definition, Range};
     use crate::packs::{ProcessedFile, UnresolvedReference};
 
     #[test]
@@ -106,6 +106,63 @@ mod tests {
         }];
 
         let definitions = vec![];
+
+        let actual = process_from_contents(contents, &absolute_path);
+        let expected = ProcessedFile {
+            absolute_path,
+            unresolved_references,
+            definitions,
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn class_definition_no_body() {
+        let contents: String = String::from(
+            "\
+class Foo
+end
+            ",
+        );
+
+        let absolute_path = PathBuf::from("path/to/file.rb");
+        let unresolved_references = vec![];
+
+        let definitions = vec![];
+
+        let actual = process_from_contents(contents, &absolute_path);
+        let expected = ProcessedFile {
+            absolute_path,
+            unresolved_references,
+            definitions,
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn class_definition_some_body() {
+        let contents: String = String::from(
+            "\
+class Foo
+  def foo
+  end
+end
+            ",
+        );
+
+        let absolute_path = PathBuf::from("path/to/file.rb");
+        let unresolved_references = vec![];
+
+        let definitions = vec![Definition {
+            fully_qualified_name: String::from("Foo"),
+            location: Range {
+                start_row: 1,
+                start_col: 0,
+                end_row: 4,
+                end_col: 3,
+            },
+            namespace_path: vec![],
+        }];
 
         let actual = process_from_contents(contents, &absolute_path);
         let expected = ProcessedFile {

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -1,0 +1,37 @@
+pub(crate) mod parser;
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::packs::parsing::ruby::experimental::parser::process_from_contents;
+    use crate::packs::parsing::Range;
+    use crate::packs::{ProcessedFile, UnresolvedReference};
+
+    #[test]
+    fn trivial_case() {
+        let contents: String = String::from("Foo");
+
+        let absolute_path = PathBuf::from("path/to/file.rb");
+        let unresolved_references = vec![UnresolvedReference {
+            name: String::from("Foo"),
+            namespace_path: vec![],
+            location: Range {
+                start_row: 1,
+                start_col: 0,
+                end_row: 1,
+                end_col: 4,
+            },
+        }];
+
+        let definitions = vec![];
+
+        let actual = process_from_contents(contents, &absolute_path);
+        let expected = ProcessedFile {
+            absolute_path,
+            unresolved_references,
+            definitions,
+        };
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -61,4 +61,58 @@ mod tests {
         };
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn deeply_nested_constant() {
+        let contents: String = String::from("Foo::Bar::Baz");
+
+        let absolute_path = PathBuf::from("path/to/file.rb");
+        let unresolved_references = vec![UnresolvedReference {
+            name: String::from("Foo::Bar::Baz"),
+            namespace_path: vec![],
+            location: Range {
+                start_row: 1,
+                start_col: 0,
+                end_row: 1,
+                end_col: 14,
+            },
+        }];
+
+        let definitions = vec![];
+
+        let actual = process_from_contents(contents, &absolute_path);
+        let expected = ProcessedFile {
+            absolute_path,
+            unresolved_references,
+            definitions,
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn very_deeply_nested_constant() {
+        let contents: String = String::from("Foo::Bar::Baz::Boo");
+
+        let absolute_path = PathBuf::from("path/to/file.rb");
+        let unresolved_references = vec![UnresolvedReference {
+            name: String::from("Foo::Bar::Baz::Boo"),
+            namespace_path: vec![],
+            location: Range {
+                start_row: 1,
+                start_col: 0,
+                end_row: 1,
+                end_col: 19,
+            },
+        }];
+
+        let definitions = vec![];
+
+        let actual = process_from_contents(contents, &absolute_path);
+        let expected = ProcessedFile {
+            absolute_path,
+            unresolved_references,
+            definitions,
+        };
+        assert_eq!(expected, actual);
+    }
 }

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -32,7 +32,7 @@ pub fn get_experimental_constant_resolver(
         })
         .collect::<Vec<Constant>>();
 
-    ConstantResolver::create(absolute_root, constants)
+    ConstantResolver::create(absolute_root, constants, false)
 }
 
 #[cfg(test)]

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -34,4 +34,31 @@ mod tests {
         };
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn nested_constant() {
+        let contents: String = String::from("Foo::Bar");
+
+        let absolute_path = PathBuf::from("path/to/file.rb");
+        let unresolved_references = vec![UnresolvedReference {
+            name: String::from("Foo::Bar"),
+            namespace_path: vec![],
+            location: Range {
+                start_row: 1,
+                start_col: 0,
+                end_row: 1,
+                end_col: 9,
+            },
+        }];
+
+        let definitions = vec![];
+
+        let actual = process_from_contents(contents, &absolute_path);
+        let expected = ProcessedFile {
+            absolute_path,
+            unresolved_references,
+            definitions,
+        };
+        assert_eq!(expected, actual);
+    }
 }

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -7,6 +7,7 @@ mod tests {
     use crate::packs::parsing::ruby::experimental::parser::process_from_contents;
     use crate::packs::parsing::{Definition, Range};
     use crate::packs::{ProcessedFile, UnresolvedReference};
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn trivial_case() {
@@ -154,12 +155,12 @@ end
         let unresolved_references = vec![];
 
         let definitions = vec![Definition {
-            fully_qualified_name: String::from("Foo"),
+            fully_qualified_name: String::from("::Foo"),
             location: Range {
                 start_row: 1,
-                start_col: 0,
-                end_row: 4,
-                end_col: 3,
+                start_col: 6,
+                end_row: 1,
+                end_col: 10,
             },
             namespace_path: vec![],
         }];

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -8,11 +8,7 @@ use lib_ruby_parser::{
 };
 use line_col::LineColLookup;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{HashMap, HashSet},
-    fs,
-    path::Path,
-};
+use std::{collections::HashSet, fs, path::Path};
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct SuperclassReference {
@@ -368,29 +364,6 @@ pub(crate) fn process_from_contents(
     };
 
     collector.visit(&ast);
-
-    let mut definition_to_location_map: HashMap<String, Range> = HashMap::new();
-
-    for d in &collector.definitions {
-        let parts: Vec<&str> = d.fully_qualified_name.split("::").collect();
-        // We do this to handle nested constants, e.g.
-        // class Foo::Bar
-        // end
-        for (index, _) in parts.iter().enumerate() {
-            let combined = &parts[..=index].join("::");
-            // If the map already contains the key, skip it.
-            // This is helpful, e.g.
-            // class Foo::Bar
-            //  BAZ
-            // end
-            // The fully name for BAZ IS ::Foo::Bar::BAZ, so we do not want to overwrite
-            // the definition location for ::Foo or ::Foo::Bar
-            if !definition_to_location_map.contains_key(combined) {
-                definition_to_location_map
-                    .insert(combined.to_owned(), d.location.clone());
-            }
-        }
-    }
 
     let unresolved_references = collector.references;
 

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -87,9 +87,9 @@ fn get_definition_from(
     let fully_qualified_name = if !owned_namespace_path.is_empty() {
         let mut name_components = owned_namespace_path.clone();
         name_components.push(name);
-        format!("::{}", name_components.join("::"))
+        name_components.join("::")
     } else {
-        format!("::{}", name)
+        name
     };
 
     Definition {
@@ -240,9 +240,9 @@ impl<'a> Visitor for ReferenceCollector<'a> {
         let fully_qualified_name = if !self.current_namespaces.is_empty() {
             let mut name_components = self.current_namespaces.clone();
             name_components.push(name);
-            format!("::{}", name_components.join("::"))
+            name_components.join("::")
         } else {
-            format!("::{}", name)
+            name
         };
 
         self.definitions.push(Definition {

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -1,1 +1,459 @@
+use crate::packs::{
+    inflector_shim::to_class_case,
+    parsing::{Definition, Range, UnresolvedReference},
+    ProcessedFile,
+};
+use lib_ruby_parser::{
+    nodes, traverse::visitor::Visitor, Loc, Node, Parser, ParserOptions,
+};
+use line_col::LineColLookup;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::Path,
+};
 
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct SuperclassReference {
+    pub name: String,
+    pub namespace_path: Vec<String>,
+}
+
+// impl UnresolvedReference {
+//     fn possible_fully_qualified_constants(&self) -> Vec<String> {
+//         if self.name.starts_with("::") {
+//             return vec![self.name.to_owned()];
+//         }
+
+//         let mut possible_constants = vec![self.name.to_owned()];
+//         let module_nesting = namespace_calculator::calculate_module_nesting(
+//             &self.namespace_path,
+//         );
+//         for nesting in module_nesting {
+//             let possible_constant = format!("::{}::{}", nesting, self.name);
+//             possible_constants.push(possible_constant);
+//         }
+
+//         possible_constants
+//     }
+// }
+
+struct ReferenceCollector<'a> {
+    pub references: Vec<UnresolvedReference>,
+    pub definitions: Vec<Definition>,
+    pub current_namespaces: Vec<String>,
+    pub line_col_lookup: LineColLookup<'a>,
+    pub in_superclass: bool,
+    pub superclasses: Vec<SuperclassReference>,
+}
+
+#[derive(Debug)]
+enum ParseError {
+    Metaprogramming,
+    // Add more variants as needed for different error cases
+}
+
+fn fetch_node_location(node: &nodes::Node) -> Result<&Loc, ParseError> {
+    match node {
+        Node::Const(const_node) => Ok(&const_node.expression_l),
+        node => {
+            dbg!(node);
+            panic!(
+                "Cannot handle other node in get_constant_node_name: {:?}",
+                node
+            )
+        }
+    }
+}
+
+fn loc_to_range(loc: &Loc, lookup: &LineColLookup) -> Range {
+    let (start_row, start_col) = lookup.get(loc.begin); // There's an off-by-one difference here with packwerk
+    let (end_row, end_col) = lookup.get(loc.end);
+
+    Range {
+        start_row,
+        start_col: start_col - 1,
+        end_row,
+        end_col,
+    }
+}
+fn fetch_const_name(node: &nodes::Node) -> Result<String, ParseError> {
+    match node {
+        Node::Const(const_node) => Ok(fetch_const_const_name(const_node)?),
+        Node::Cbase(_) => Ok(String::from("")),
+        Node::Send(_) => Err(ParseError::Metaprogramming),
+        Node::Lvar(_) => Err(ParseError::Metaprogramming),
+        Node::Ivar(_) => Err(ParseError::Metaprogramming),
+        Node::Self_(_) => Err(ParseError::Metaprogramming),
+        node => {
+            dbg!(node);
+            panic!(
+                "Cannot handle other node in get_constant_node_name: {:?}",
+                node
+            )
+        }
+    }
+}
+
+fn fetch_const_const_name(node: &nodes::Const) -> Result<String, ParseError> {
+    match &node.scope {
+        Some(s) => {
+            let parent_namespace = fetch_const_name(s)?;
+            Ok(format!("{}::{}", parent_namespace, node.name))
+        }
+        None => Ok(node.name.to_owned()),
+    }
+}
+
+fn get_definition_from(
+    current_nesting: &String,
+    parent_nesting: &[String],
+    location: &Range,
+) -> Definition {
+    let name = current_nesting.to_owned();
+
+    let owned_namespace_path: Vec<String> = parent_nesting.to_vec();
+
+    let fully_qualified_name = if !owned_namespace_path.is_empty() {
+        let mut name_components = owned_namespace_path.clone();
+        name_components.push(name);
+        format!("::{}", name_components.join("::"))
+    } else {
+        format!("::{}", name)
+    };
+
+    Definition {
+        fully_qualified_name,
+        namespace_path: owned_namespace_path,
+        location: location.to_owned(),
+    }
+}
+
+// TODO: Combine with fetch_const_const_name
+fn fetch_casgn_name(node: &nodes::Casgn) -> Result<String, ParseError> {
+    match &node.scope {
+        Some(s) => {
+            let parent_namespace = fetch_const_name(s)?;
+            Ok(format!("{}::{}", parent_namespace, node.name))
+        }
+        None => Ok(node.name.to_owned()),
+    }
+}
+
+fn extract_class_name_from_kwargs(kwargs: &nodes::Kwargs) -> Option<String> {
+    for pair_node in kwargs.pairs.iter() {
+        if let Node::Pair(pair) = pair_node {
+            if let Node::Sym(k) = *pair.key.to_owned() {
+                if k.name.to_string_lossy() == *"class_name" {
+                    if let Node::Str(v) = *pair.value.to_owned() {
+                        return Some(v.value.to_string_lossy());
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+impl<'a> Visitor for ReferenceCollector<'a> {
+    fn on_class(&mut self, node: &nodes::Class) {
+        // We're not collecting definitions, so no need to visit the class definitioname);
+        let namespace_result = fetch_const_name(&node.name);
+        // For now, we simply exit and stop traversing if we encounter an error when fetching the constant name of a class
+        // We can iterate on this if this is different than the packwerk implementation
+        if namespace_result.is_err() {
+            return;
+        }
+
+        let namespace = namespace_result.unwrap();
+
+        if let Some(inner) = node.superclass.as_ref() {
+            // dbg!("Visiting superclass!: {:?}", inner);
+            self.in_superclass = true;
+            self.visit(inner);
+            self.in_superclass = false;
+        }
+        let definition_loc = fetch_node_location(&node.name).unwrap();
+        let location = loc_to_range(definition_loc, &self.line_col_lookup);
+
+        let definition = get_definition_from(
+            &namespace,
+            &self.current_namespaces,
+            &location,
+        );
+
+        // Note – is there a way to use lifetime specifiers to get rid of this and
+        // just keep current namespaces as a vector of string references or something else
+        // more efficient?
+        self.current_namespaces.push(namespace);
+
+        let name = definition.fully_qualified_name.to_owned();
+        let namespace_path = definition.namespace_path.to_owned();
+        self.definitions.push(definition);
+
+        // Packwerk also considers a definition to be a "reference"
+        self.references.push(UnresolvedReference {
+            name,
+            namespace_path,
+            location,
+        });
+
+        if let Some(inner) = &node.body {
+            self.visit(inner);
+        }
+
+        self.current_namespaces.pop();
+        self.superclasses.pop();
+    }
+
+    fn on_send(&mut self, node: &nodes::Send) {
+        // TODO: Read in args, process associations as a separate class
+        // These can get complicated! e.g. we can specify a class name
+        // dbg!(&node);
+        if node.method_name == *"has_one"
+            || node.method_name == *"has_many"
+            || node.method_name == *"belongs_to"
+            || node.method_name == *"has_and_belongs_to_many"
+        {
+            let first_arg: Option<&Node> = node.args.get(0);
+
+            let mut name: Option<String> = None;
+            for node in node.args.iter() {
+                if let Node::Kwargs(kwargs) = node {
+                    if let Some(found) = extract_class_name_from_kwargs(kwargs)
+                    {
+                        name = Some(found);
+                    }
+                }
+            }
+
+            if let Some(Node::Sym(d)) = first_arg {
+                if name.is_none() {
+                    // We singularize here because by convention Rails will singularize the class name as declared via a symbol,
+                    // e.g. `has_many :companies` will look for a class named `Company`, not `Companies`
+                    name = Some(to_class_case(
+                        &d.name.to_string_lossy(),
+                        true,
+                        &HashSet::new(), // todo: pass in acronyms here
+                    ));
+                }
+            }
+
+            // let unwrapped_name = name.unwrap_or_else(|| {
+            //     panic!("Could not find class name for association {:?}", &node,)
+            // });
+            // Later we should probably handle these cases!
+            if name.is_some() {
+                let unwrapped_name = name.unwrap_or_else(|| {
+                    panic!(
+                        "Could not find class name for association {:?}",
+                        &node,
+                    )
+                });
+
+                self.references.push(UnresolvedReference {
+                    name: unwrapped_name,
+                    namespace_path: self.current_namespaces.to_owned(),
+                    location: loc_to_range(
+                        &node.expression_l,
+                        &self.line_col_lookup,
+                    ),
+                })
+            }
+        }
+
+        lib_ruby_parser::traverse::visitor::visit_send(self, node);
+    }
+
+    fn on_casgn(&mut self, node: &nodes::Casgn) {
+        let name_result = fetch_casgn_name(node);
+        if name_result.is_err() {
+            return;
+        }
+
+        // TODO: This can be extracted from on_class
+        let name = name_result.unwrap();
+        let fully_qualified_name = if !self.current_namespaces.is_empty() {
+            let mut name_components = self.current_namespaces.clone();
+            name_components.push(name);
+            format!("::{}", name_components.join("::"))
+        } else {
+            format!("::{}", name)
+        };
+
+        self.definitions.push(Definition {
+            fully_qualified_name,
+            namespace_path: self.current_namespaces.to_owned(),
+            location: loc_to_range(&node.expression_l, &self.line_col_lookup),
+        });
+
+        if let Some(v) = node.value.to_owned() {
+            self.visit(&v);
+        } else {
+            // We don't handle constant assignments as part of a multi-assignment yet,
+            // e.g. A, B = 1, 2
+            // See the documentation for nodes::Casgn#value for more info.
+        }
+    }
+
+    fn on_module(&mut self, node: &nodes::Module) {
+        let namespace = fetch_const_name(&node.name)
+            .expect("We expect no parse errors in class/module definitions");
+        let definition_loc = fetch_node_location(&node.name).unwrap();
+        let location = loc_to_range(definition_loc, &self.line_col_lookup);
+
+        let definition = get_definition_from(
+            &namespace,
+            &self.current_namespaces,
+            &location,
+        );
+
+        // Note – is there a way to use lifetime specifiers to get rid of this and
+        // just keep current namespaces as a vector of string references or something else
+        // more efficient?
+        self.current_namespaces.push(namespace);
+
+        let name = definition.fully_qualified_name.to_owned();
+        let namespace_path = definition.namespace_path.to_owned();
+        self.definitions.push(definition);
+
+        // Packwerk also considers a definition to be a "reference"
+        self.references.push(UnresolvedReference {
+            name,
+            namespace_path,
+            location,
+        });
+
+        if let Some(inner) = &node.body {
+            self.visit(inner);
+        }
+
+        self.current_namespaces.pop();
+    }
+
+    fn on_const(&mut self, node: &nodes::Const) {
+        let Ok(name) = fetch_const_const_name(node) else { return };
+
+        if self.in_superclass {
+            self.superclasses.push(SuperclassReference {
+                name: name.to_owned(),
+                namespace_path: self.current_namespaces.to_owned(),
+            })
+        }
+        // In packwerk, NodeHelpers.enclosing_namespace_path ignores
+        // namespaces where a superclass OR namespace is the same as the current reference name
+        let matching_superclass_option = self
+            .superclasses
+            .iter()
+            .find(|superclass| superclass.name == name);
+
+        let namespace_path =
+            if let Some(matching_superclass) = matching_superclass_option {
+                matching_superclass.namespace_path.to_owned()
+            } else {
+                self.current_namespaces
+                    .clone()
+                    .into_iter()
+                    .filter(|namespace| {
+                        namespace != &name
+                            || self
+                                .superclasses
+                                .iter()
+                                .any(|superclass| superclass.name == name)
+                    })
+                    .collect::<Vec<String>>()
+            };
+
+        self.references.push(UnresolvedReference {
+            name,
+            namespace_path,
+            location: loc_to_range(&node.expression_l, &self.line_col_lookup),
+        })
+    }
+}
+
+pub(crate) fn process_from_path(path: &Path) -> ProcessedFile {
+    let contents = fs::read_to_string(path).unwrap_or_else(|_| {
+        panic!("Failed to read contents of {}", path.to_string_lossy())
+    });
+
+    process_from_contents(contents, path)
+}
+
+pub(crate) fn process_from_contents(
+    contents: String,
+    path: &Path,
+) -> ProcessedFile {
+    let options = ParserOptions {
+        buffer_name: "".to_string(),
+        ..Default::default()
+    };
+
+    let lookup = LineColLookup::new(&contents);
+    let parser = Parser::new(contents.clone(), options);
+    let parse_result = parser.do_parse();
+
+    let ast_option: Option<Box<Node>> = parse_result.ast;
+
+    let ast = match ast_option {
+        Some(some_ast) => some_ast,
+        None => {
+            return ProcessedFile {
+                absolute_path: path.to_owned(),
+                unresolved_references: vec![],
+                definitions: vec![],
+            }
+        }
+    };
+
+    let mut collector = ReferenceCollector {
+        references: vec![],
+        current_namespaces: vec![],
+        definitions: vec![],
+        line_col_lookup: lookup,
+        in_superclass: false,
+        superclasses: vec![],
+    };
+
+    collector.visit(&ast);
+
+    let mut definition_to_location_map: HashMap<String, Range> = HashMap::new();
+
+    for d in &collector.definitions {
+        let parts: Vec<&str> = d.fully_qualified_name.split("::").collect();
+        // We do this to handle nested constants, e.g.
+        // class Foo::Bar
+        // end
+        for (index, _) in parts.iter().enumerate() {
+            let combined = &parts[..=index].join("::");
+            // If the map already contains the key, skip it.
+            // This is helpful, e.g.
+            // class Foo::Bar
+            //  BAZ
+            // end
+            // The fully name for BAZ IS ::Foo::Bar::BAZ, so we do not want to overwrite
+            // the definition location for ::Foo or ::Foo::Bar
+            if !definition_to_location_map.contains_key(combined) {
+                definition_to_location_map
+                    .insert(combined.to_owned(), d.location.clone());
+            }
+        }
+    }
+
+    let unresolved_references = collector.references;
+
+    let absolute_path = path.to_owned();
+
+    // The packwerk parser uses a ConstantResolver constructed by constants inferred from the file system
+    // see zeitwerk_utils for more.
+    // For a parser that uses parsed constants, see the experimental parser
+    let definitions = vec![];
+
+    ProcessedFile {
+        absolute_path,
+        unresolved_references,
+        definitions,
+    }
+}

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -7,14 +7,7 @@ use lib_ruby_parser::{
     nodes, traverse::visitor::Visitor, Loc, Node, Parser, ParserOptions,
 };
 use line_col::LineColLookup;
-use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, fs, path::Path};
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-struct SuperclassReference {
-    pub name: String,
-    pub namespace_path: Vec<String>,
-}
 
 struct ReferenceCollector<'a> {
     pub references: Vec<UnresolvedReference>,

--- a/src/packs/parsing/ruby/mod.rs
+++ b/src/packs/parsing/ruby/mod.rs
@@ -1,3 +1,4 @@
+pub mod experimental;
 pub mod namespace_calculator;
 pub mod packwerk;
 pub(crate) mod rails_utils;

--- a/src/packs/parsing/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parsing/ruby/packwerk/constant_resolver.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ConstantResolver {
     pub fully_qualified_constant_to_constant_map: HashMap<String, Constant>,
 }

--- a/src/packs/parsing/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parsing/ruby/packwerk/constant_resolver.rs
@@ -22,6 +22,7 @@ impl ConstantResolver {
     pub fn create(
         absolute_root: &Path,
         constants: Vec<Constant>,
+        disallow_multiple_definitions: bool,
     ) -> ConstantResolver {
         debug!("Building constant resolver");
 
@@ -47,11 +48,12 @@ impl ConstantResolver {
 
                 // Later, we can allow the checkers to skip over constants where it's pointing at a pack that defines it as an ignored_monkeypatch: path/to/definition.rb
                 // We should be sure to validate that ignored_monkeypatch paths match the absolute_path_to_definition of the constant.
-                //
-                // panic!(
-                //     "Found two constants with the same name: {:?} and {:?}",
-                //     existing_constant, constant
-                // );
+                if disallow_multiple_definitions {
+                    panic!(
+                        "Found two constants with the same name: {:?} and {:?}",
+                        existing_constant, constant
+                    );
+                }
             } else {
                 fully_qualified_constant_to_constant_map
                     .insert(fully_qualified_constant_name, constant);

--- a/src/packs/parsing/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parsing/ruby/packwerk/constant_resolver.rs
@@ -41,10 +41,17 @@ impl ConstantResolver {
                 .get(&fully_qualified_constant_name);
 
             if let Some(existing_constant) = existing_constant {
-                panic!(
-                    "Found two constants with the same name: {:?} and {:?}",
-                    existing_constant, constant
-                );
+                // TODO: This still needs to be handled more elegantly. For now, we just panic.
+                // Probably, we should have the HashMap have a Vec<Constant> instead of a single Constant, and then we can add to the Vec.
+                // Then, when we create references, we can create one reference to each unique pack that defines the constant.
+
+                // Later, we can allow the checkers to skip over constants where it's pointing at a pack that defines it as an ignored_monkeypatch: path/to/definition.rb
+                // We should be sure to validate that ignored_monkeypatch paths match the absolute_path_to_definition of the constant.
+                //
+                // panic!(
+                //     "Found two constants with the same name: {:?} and {:?}",
+                //     existing_constant, constant
+                // );
             } else {
                 fully_qualified_constant_to_constant_map
                     .insert(fully_qualified_constant_name, constant);

--- a/src/packs/parsing/ruby/zeitwerk_utils.rs
+++ b/src/packs/parsing/ruby/zeitwerk_utils.rs
@@ -26,7 +26,7 @@ pub fn get_zeitwerk_constant_resolver(
         cache_dir,
         cache_disabled,
     );
-    ConstantResolver::create(absolute_root, constants)
+    ConstantResolver::create(absolute_root, constants, true)
 }
 
 fn inferred_constants_from_pack_set(

--- a/src/packs/per_file_cache.rs
+++ b/src/packs/per_file_cache.rs
@@ -207,7 +207,7 @@ mod tests {
     fn test_file_content_digest() {
         let file_path =
             "tests/fixtures/simple_app/packs/bar/app/services/bar.rb";
-        let expected_digest = "f2af2fc657b71331ff3a8c39b48365eb";
+        let expected_digest = "305bc58696c2e664057b6751064cf2e3";
 
         let digest = file_content_digest(&PathBuf::from(file_path));
 

--- a/src/packs/per_file_cache.rs
+++ b/src/packs/per_file_cache.rs
@@ -56,7 +56,7 @@ impl CacheEntry {
         ProcessedFile {
             unresolved_references,
             absolute_path: absolute_path.to_owned(),
-            definitions: vec![], // TODO
+            definitions: self.definitions,
         }
     }
 }

--- a/src/packs/per_file_cache.rs
+++ b/src/packs/per_file_cache.rs
@@ -3,11 +3,12 @@ use crate::packs::SourceLocation;
 use serde::{Deserialize, Serialize};
 
 use std::env;
-use std::fs::{self, File};
-use std::io::{Read, Write};
+use std::fs::File;
+use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
+use super::file_utils::file_content_digest;
 use super::parsing::{Cache, Range};
 use super::{ProcessedFile, UnresolvedReference};
 
@@ -90,20 +91,6 @@ pub fn read_json_file(
     let reader = std::io::BufReader::new(file);
     let data = serde_json::from_reader(reader)?;
     Ok(data)
-}
-
-pub(crate) fn file_content_digest(file: &Path) -> String {
-    let mut file_content = Vec::new();
-
-    // Read the file content
-    let mut file_handle = fs::File::open(file)
-        .unwrap_or_else(|_| panic!("Failed to open file {:?}", file));
-    file_handle
-        .read_to_end(&mut file_content)
-        .expect("Failed to read file");
-
-    // Compute the MD5 digest
-    format!("{:x}", md5::compute(&file_content))
 }
 
 #[derive(Debug)]

--- a/src/packs/per_file_cache.rs
+++ b/src/packs/per_file_cache.rs
@@ -266,7 +266,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compatible_with_alternate_extractor() {
+    fn test_compatible_with_alternate_parser() {
         let contents: String = String::from(
             r#"{
     "file_contents_digest": "8f9efdcf2caa22fb7b1b4a8274e68d11",

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -36,8 +36,7 @@ fn test_check_with_package_todo_file() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[should_panic(expected = "The experimental parser is coming soon!")]
-fn test_check_with_experimental_parser() {
+fn test_check_with_experimental_parser() -> Result<(), Box<dyn Error>> {
     Command::cargo_bin("packs")
         .unwrap()
         .arg("--project-root")
@@ -45,7 +44,11 @@ fn test_check_with_experimental_parser() {
         .arg("--experimental-parser")
         .arg("check")
         .assert()
-        .success();
+        .failure()
+        .stdout(predicate::str::contains("2 violation(s) detected:"))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
 
     common::teardown();
+    Ok(())
 }

--- a/tests/fixtures/simple_app/packs/bar/app/services/bar.rb
+++ b/tests/fixtures/simple_app/packs/bar/app/services/bar.rb
@@ -1,2 +1,3 @@
 module Bar
+  def bar; end
 end

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -46,8 +46,7 @@ packs/bar:
 }
 
 #[test]
-#[should_panic(expected = "The experimental parser is coming soon!")]
-fn test_check_with_experimental_parser() {
+fn test_update_with_experimental_parser() -> Result<(), Box<dyn Error>> {
     Command::cargo_bin("packs")
         .unwrap()
         .arg("--project-root")
@@ -55,7 +54,37 @@ fn test_check_with_experimental_parser() {
         .arg("--experimental-parser")
         .arg("update")
         .assert()
-        .success();
+        .success()
+        .stdout(predicate::str::contains(
+            "Successfully updated package_todo.yml files!",
+        ));
+
+    let package_todo_yml_filepath =
+        Path::new("tests/fixtures/simple_app/packs/foo/package_todo.yml");
+    let actual = std::fs::read_to_string(package_todo_yml_filepath)?;
+    let expected = String::from(
+        "\
+# This file contains a list of dependencies that are not part of the long term plan for the
+# 'packs/foo' package.
+# We should generally work to reduce this list over time.
+#
+# You can regenerate this file using the following command:
+#
+# bin/packwerk update-todo
+---
+packs/bar:
+  \"::Bar\":
+    violations:
+    - dependency
+    - privacy
+    files:
+    - packs/foo/app/services/foo.rb
+",
+    );
+    std::fs::remove_file(package_todo_yml_filepath)?;
+    assert_eq!(expected, actual);
 
     common::teardown();
+
+    Ok(())
 }


### PR DESCRIPTION
This enables an alpha version of the experimental parser, which allows `packwerk` to be used in non-rails apps.
