### PR TITLE
Simplify cache trait

### DIFF
--- a/src/packs.rs
+++ b/src/packs.rs
@@ -20,6 +20,7 @@ mod pack_set;
 pub mod package_todo;
 pub mod parsing;
 pub(crate) mod per_file_cache;
+pub(crate) mod reference_graph_builder;
 mod walk_directory;
 
 // Re-exports: Eventually, these may be part of the public API for packs

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -9,6 +9,7 @@ use std::hash::Hasher;
 use std::io::Read;
 use std::path::Path;
 use std::path::PathBuf;
+pub(crate) mod caching;
 pub(crate) mod checker;
 pub mod cli;
 pub(crate) mod file_utils;

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -20,7 +20,6 @@ mod pack_set;
 pub mod package_todo;
 pub mod parsing;
 pub(crate) mod per_file_cache;
-pub(crate) mod reference_graph_builder;
 mod walk_directory;
 
 // Re-exports: Eventually, these may be part of the public API for packs

--- a/src/packs/caching.rs
+++ b/src/packs/caching.rs
@@ -1,12 +1,55 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use super::ProcessedFile;
+use super::{file_utils::file_content_digest, ProcessedFile};
+
+#[derive(Debug)]
+pub struct CachableFile {
+    pub relative_path: PathBuf,
+    pub file_contents_digest: String,
+    pub cache_file_path: PathBuf,
+}
+
+impl CachableFile {
+    // Pass in Configuration and get cache_dir from that
+    pub fn new(
+        absolute_root: &Path,
+        cache_directory: &Path,
+        filepath: &Path,
+    ) -> CachableFile {
+        let relative_path: PathBuf =
+            filepath.strip_prefix(absolute_root).unwrap().to_path_buf();
+
+        let file_digest = md5::compute(relative_path.to_str().unwrap());
+        let file_digest_str = format!("{:x}", file_digest);
+        let cache_file_path = cache_directory.join(file_digest_str);
+
+        let file_contents_digest = file_content_digest(filepath);
+
+        CachableFile {
+            relative_path,
+            file_contents_digest,
+            cache_file_path,
+        }
+    }
+
+    pub fn relative_path_string(&self) -> &str {
+        self.relative_path.to_str().unwrap()
+    }
+}
 
 pub trait Cache {
-    fn process_file(
+    // fn process_file(
+    //     &self,
+    //     absolute_root: &Path,
+    //     path: &Path,
+    //     experimental_parser: bool,
+    // ) -> ProcessedFile;
+
+    fn get(&self, absolute_root: &Path, path: &Path) -> Option<ProcessedFile>;
+
+    fn write(
         &self,
-        absolute_root: &Path,
-        path: &Path,
-        experimental_parser: bool,
-    ) -> ProcessedFile;
+        cachable_file: &CachableFile,
+        processed_file: &ProcessedFile,
+    );
 }

--- a/src/packs/caching.rs
+++ b/src/packs/caching.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+use super::ProcessedFile;
+
+pub trait Cache {
+    fn process_file(
+        &self,
+        absolute_root: &Path,
+        path: &Path,
+        experimental_parser: bool,
+    ) -> ProcessedFile;
+}

--- a/src/packs/caching.rs
+++ b/src/packs/caching.rs
@@ -4,24 +4,24 @@ use super::{file_utils::file_content_digest, ProcessedFile};
 
 pub enum CacheResult {
     Processed(ProcessedFile),
-    Miss(CacheMiss),
+    Miss(EmptyCacheEntry),
 }
 
 #[derive(Debug, Default)]
-pub struct CacheMiss {
+pub struct EmptyCacheEntry {
     pub relative_path: PathBuf,
     pub file_contents_digest: String,
     pub file_name_digest: String,
     pub cache_file_path: PathBuf,
 }
 
-impl CacheMiss {
+impl EmptyCacheEntry {
     // Pass in Configuration and get cache_dir from that
     pub fn new(
         absolute_root: &Path,
         cache_directory: &Path,
         filepath: &Path,
-    ) -> CacheMiss {
+    ) -> EmptyCacheEntry {
         let relative_path: PathBuf =
             filepath.strip_prefix(absolute_root).unwrap().to_path_buf();
 
@@ -31,7 +31,7 @@ impl CacheMiss {
 
         let file_contents_digest = file_content_digest(filepath);
 
-        CacheMiss {
+        EmptyCacheEntry {
             relative_path,
             file_contents_digest,
             cache_file_path,
@@ -54,5 +54,9 @@ pub trait Cache {
 
     fn get(&self, absolute_root: &Path, path: &Path) -> CacheResult;
 
-    fn write(&self, cache_miss: &CacheMiss, processed_file: &ProcessedFile);
+    fn write(
+        &self,
+        empty_cache_entry: &EmptyCacheEntry,
+        processed_file: &ProcessedFile,
+    );
 }

--- a/src/packs/caching.rs
+++ b/src/packs/caching.rs
@@ -11,6 +11,7 @@ pub enum CacheResult {
 pub struct CacheMiss {
     pub relative_path: PathBuf,
     pub file_contents_digest: String,
+    pub file_name_digest: String,
     pub cache_file_path: PathBuf,
 }
 
@@ -25,8 +26,8 @@ impl CacheMiss {
             filepath.strip_prefix(absolute_root).unwrap().to_path_buf();
 
         let file_digest = md5::compute(relative_path.to_str().unwrap());
-        let file_digest_str = format!("{:x}", file_digest);
-        let cache_file_path = cache_directory.join(file_digest_str);
+        let file_name_digest = format!("{:x}", file_digest);
+        let cache_file_path = cache_directory.join(&file_name_digest);
 
         let file_contents_digest = file_content_digest(filepath);
 
@@ -34,6 +35,7 @@ impl CacheMiss {
             relative_path,
             file_contents_digest,
             cache_file_path,
+            file_name_digest,
         }
     }
 

--- a/src/packs/caching.rs
+++ b/src/packs/caching.rs
@@ -2,7 +2,12 @@ use std::path::{Path, PathBuf};
 
 use super::{file_utils::file_content_digest, ProcessedFile};
 
-#[derive(Debug)]
+pub enum CacheResult {
+    Processed(ProcessedFile),
+    Miss(CacheMiss),
+}
+
+#[derive(Debug, Default)]
 pub struct CacheMiss {
     pub relative_path: PathBuf,
     pub file_contents_digest: String,
@@ -45,7 +50,7 @@ pub trait Cache {
     //     experimental_parser: bool,
     // ) -> ProcessedFile;
 
-    fn get(&self, absolute_root: &Path, path: &Path) -> Option<ProcessedFile>;
+    fn get(&self, absolute_root: &Path, path: &Path) -> CacheResult;
 
     fn write(&self, cache_miss: &CacheMiss, processed_file: &ProcessedFile);
 }

--- a/src/packs/caching.rs
+++ b/src/packs/caching.rs
@@ -3,19 +3,19 @@ use std::path::{Path, PathBuf};
 use super::{file_utils::file_content_digest, ProcessedFile};
 
 #[derive(Debug)]
-pub struct CachableFile {
+pub struct CacheMiss {
     pub relative_path: PathBuf,
     pub file_contents_digest: String,
     pub cache_file_path: PathBuf,
 }
 
-impl CachableFile {
+impl CacheMiss {
     // Pass in Configuration and get cache_dir from that
     pub fn new(
         absolute_root: &Path,
         cache_directory: &Path,
         filepath: &Path,
-    ) -> CachableFile {
+    ) -> CacheMiss {
         let relative_path: PathBuf =
             filepath.strip_prefix(absolute_root).unwrap().to_path_buf();
 
@@ -25,7 +25,7 @@ impl CachableFile {
 
         let file_contents_digest = file_content_digest(filepath);
 
-        CachableFile {
+        CacheMiss {
             relative_path,
             file_contents_digest,
             cache_file_path,
@@ -47,9 +47,5 @@ pub trait Cache {
 
     fn get(&self, absolute_root: &Path, path: &Path) -> Option<ProcessedFile>;
 
-    fn write(
-        &self,
-        cachable_file: &CachableFile,
-        processed_file: &ProcessedFile,
-    );
+    fn write(&self, cache_miss: &CacheMiss, processed_file: &ProcessedFile);
 }

--- a/src/packs/caching.rs
+++ b/src/packs/caching.rs
@@ -16,7 +16,6 @@ pub struct EmptyCacheEntry {
 }
 
 impl EmptyCacheEntry {
-    // Pass in Configuration and get cache_dir from that
     pub fn new(
         absolute_root: &Path,
         cache_directory: &Path,

--- a/src/packs/caching.rs
+++ b/src/packs/caching.rs
@@ -45,13 +45,6 @@ impl EmptyCacheEntry {
 }
 
 pub trait Cache {
-    // fn process_file(
-    //     &self,
-    //     absolute_root: &Path,
-    //     path: &Path,
-    //     experimental_parser: bool,
-    // ) -> ProcessedFile;
-
     fn get(&self, absolute_root: &Path, path: &Path) -> CacheResult;
 
     fn write(

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -14,9 +14,8 @@ use std::path::Path;
 use std::{collections::HashSet, path::PathBuf};
 use tracing::debug;
 
-use super::parsing::{
-    ruby::packwerk::constant_resolver::ConstantResolver, Cache,
-};
+use super::caching::Cache;
+use super::parsing::ruby::packwerk::constant_resolver::ConstantResolver;
 use super::Pack;
 use super::UnresolvedReference;
 

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -1,7 +1,7 @@
 use super::file_utils::user_inputted_paths_to_absolute_filepaths;
-use super::parsing::Cache;
 use super::{checker::architecture::Layers, per_file_cache};
 use super::{noop_cache, PackSet};
+use crate::packs::caching::Cache;
 
 use crate::packs::raw_configuration;
 use crate::packs::walk_directory::WalkDirectoryResult;

--- a/src/packs/noop_cache.rs
+++ b/src/packs/noop_cache.rs
@@ -1,9 +1,7 @@
 use std::path::Path;
 
-use super::{
-    parsing::{process_file, Cache},
-    ProcessedFile,
-};
+use super::{parsing::process_file, ProcessedFile};
+use crate::packs::caching::Cache;
 
 pub struct NoopCache {}
 

--- a/src/packs/noop_cache.rs
+++ b/src/packs/noop_cache.rs
@@ -1,18 +1,17 @@
 use std::path::Path;
 
-use super::ProcessedFile;
+use super::{
+    caching::{CacheMiss, CacheResult},
+    ProcessedFile,
+};
 use crate::packs::caching::Cache;
 
 pub struct NoopCache {}
 
 impl Cache for NoopCache {
-    fn get(
-        &self,
-        _absolute_root: &Path,
-        _path: &Path,
-    ) -> Option<ProcessedFile> {
+    fn get(&self, _absolute_root: &Path, _path: &Path) -> CacheResult {
         // Return nothing!
-        None
+        CacheResult::Miss(CacheMiss::default())
     }
 
     fn write(

--- a/src/packs/noop_cache.rs
+++ b/src/packs/noop_cache.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use super::{
-    caching::{CacheMiss, CacheResult},
+    caching::{CacheResult, EmptyCacheEntry},
     ProcessedFile,
 };
 use crate::packs::caching::Cache;
@@ -11,12 +11,12 @@ pub struct NoopCache {}
 impl Cache for NoopCache {
     fn get(&self, _absolute_root: &Path, _path: &Path) -> CacheResult {
         // Return nothing!
-        CacheResult::Miss(CacheMiss::default())
+        CacheResult::Miss(EmptyCacheEntry::default())
     }
 
     fn write(
         &self,
-        _cache_miss: &super::caching::CacheMiss,
+        _empty_cache_entry: &super::caching::EmptyCacheEntry,
         _processed_file: &ProcessedFile,
     ) {
         // Do nothing!

--- a/src/packs/noop_cache.rs
+++ b/src/packs/noop_cache.rs
@@ -1,17 +1,25 @@
 use std::path::Path;
 
-use super::{parsing::process_file, ProcessedFile};
+use super::ProcessedFile;
 use crate::packs::caching::Cache;
 
 pub struct NoopCache {}
 
 impl Cache for NoopCache {
-    fn process_file(
+    fn get(
         &self,
         _absolute_root: &Path,
-        path: &Path,
-        experimental_parser: bool,
-    ) -> ProcessedFile {
-        process_file(path, experimental_parser)
+        _path: &Path,
+    ) -> Option<ProcessedFile> {
+        // Return nothing!
+        None
+    }
+
+    fn write(
+        &self,
+        _cachable_file: &super::caching::CachableFile,
+        _processed_file: &ProcessedFile,
+    ) {
+        // Do nothing!
     }
 }

--- a/src/packs/noop_cache.rs
+++ b/src/packs/noop_cache.rs
@@ -17,7 +17,7 @@ impl Cache for NoopCache {
 
     fn write(
         &self,
-        _cachable_file: &super::caching::CachableFile,
+        _cache_miss: &super::caching::CacheMiss,
         _processed_file: &ProcessedFile,
     ) {
         // Do nothing!

--- a/src/packs/parsing.rs
+++ b/src/packs/parsing.rs
@@ -83,10 +83,10 @@ pub fn process_files_with_cache(
         .map(|absolute_path| -> ProcessedFile {
             match cache.get(absolute_root, absolute_path) {
                 CacheResult::Processed(processed_file) => processed_file,
-                CacheResult::Miss(cache_miss) => {
+                CacheResult::Miss(empty_cache_entry) => {
                     let processed_file =
                         process_file(absolute_path, experimental_parser);
-                    cache.write(&cache_miss, &processed_file);
+                    cache.write(&empty_cache_entry, &processed_file);
                     processed_file
                 }
             }

--- a/src/packs/parsing.rs
+++ b/src/packs/parsing.rs
@@ -81,11 +81,10 @@ pub fn process_files_with_cache(
     paths
         .par_iter()
         .map(|absolute_path| -> ProcessedFile {
-            cache.process_file(
-                absolute_root,
-                absolute_path,
-                experimental_parser,
-            )
+            match cache.get(absolute_root, absolute_path) {
+                Some(processed_file) => processed_file,
+                None => process_file(absolute_path, experimental_parser),
+            }
         })
         .collect()
 }

--- a/src/packs/parsing.rs
+++ b/src/packs/parsing.rs
@@ -14,6 +14,7 @@ use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 
 use super::{
+    caching::Cache,
     file_utils::{get_file_type, SupportedFileType},
     ProcessedFile,
 };
@@ -69,15 +70,6 @@ pub struct Definition {
     pub fully_qualified_name: String,
     pub location: Range,
     pub namespace_path: Vec<String>,
-}
-
-pub trait Cache {
-    fn process_file(
-        &self,
-        absolute_root: &Path,
-        path: &Path,
-        experimental_parser: bool,
-    ) -> ProcessedFile;
 }
 
 pub fn process_files_with_cache(

--- a/src/packs/per_file_cache.rs
+++ b/src/packs/per_file_cache.rs
@@ -8,9 +8,10 @@ use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
+use super::caching::Cache;
 use super::file_utils::file_content_digest;
 use super::parsing::Definition;
-use super::parsing::{Cache, Range};
+use super::parsing::Range;
 use super::{ProcessedFile, UnresolvedReference};
 
 pub struct PerFileCache {

--- a/src/packs/per_file_cache.rs
+++ b/src/packs/per_file_cache.rs
@@ -22,7 +22,7 @@ impl Cache for PerFileCache {
     fn get(&self, absolute_root: &Path, path: &Path) -> CacheResult {
         let empty_cache_entry =
             EmptyCacheEntry::new(absolute_root, &self.cache_dir, path);
-        let cache_entry = cache_entry_for_file(&empty_cache_entry);
+        let cache_entry = cache_entry_from_empty(&empty_cache_entry);
         if let Some(cache_entry) = cache_entry {
             let file_digests_match = cache_entry.file_contents_digest
                 == empty_cache_entry.file_contents_digest;
@@ -86,8 +86,8 @@ impl Cache for PerFileCache {
     }
 }
 
-fn cache_entry_for_file(file: &EmptyCacheEntry) -> Option<CacheEntry> {
-    let cache_file_path = &file.cache_file_path;
+fn cache_entry_from_empty(empty: &EmptyCacheEntry) -> Option<CacheEntry> {
+    let cache_file_path = &empty.cache_file_path;
 
     if cache_file_path.exists() {
         Some(read_json_file(cache_file_path).unwrap_or_else(|_| {

--- a/src/packs/per_file_cache.rs
+++ b/src/packs/per_file_cache.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use super::caching::Cache;
 use super::caching::CacheMiss;
 
+use super::caching::CacheResult;
 use super::parsing::Definition;
 use super::parsing::Range;
 use super::{ProcessedFile, UnresolvedReference};
@@ -18,7 +19,7 @@ pub struct PerFileCache {
 }
 
 impl Cache for PerFileCache {
-    fn get(&self, absolute_root: &Path, path: &Path) -> Option<ProcessedFile> {
+    fn get(&self, absolute_root: &Path, path: &Path) -> CacheResult {
         let cache_miss = CacheMiss::new(absolute_root, &self.cache_dir, path);
         let cache_entry = cache_entry_for_file(&cache_miss);
         if let Some(cache_entry) = cache_entry {
@@ -26,13 +27,13 @@ impl Cache for PerFileCache {
                 == cache_miss.file_contents_digest;
 
             if !file_digests_match {
-                None
+                CacheResult::Miss(cache_miss)
             } else {
                 let processed_file = cache_entry.processed_file(path);
-                Some(processed_file)
+                CacheResult::Processed(processed_file)
             }
         } else {
-            None
+            CacheResult::Miss(cache_miss)
         }
     }
 

--- a/src/packs/reference_graph_builder.rs
+++ b/src/packs/reference_graph_builder.rs
@@ -1,0 +1,9 @@
+use super::{
+    checker::Reference,
+    parsing::ruby::packwerk::constant_resolver::ConstantResolver,
+};
+
+pub struct ReferenceGraph {
+    pub references: Vec<Reference>,
+    pub constant_resolver: ConstantResolver,
+}

--- a/src/packs/reference_graph_builder.rs
+++ b/src/packs/reference_graph_builder.rs
@@ -1,9 +1,0 @@
-use super::{
-    checker::Reference,
-    parsing::ruby::packwerk::constant_resolver::ConstantResolver,
-};
-
-pub struct ReferenceGraph {
-    pub references: Vec<Reference>,
-    pub constant_resolver: ConstantResolver,
-}


### PR DESCRIPTION
- move cache to own module
- simplify caching so it simply has a get and write function
- rename CachableFile to CacheMiss
- refactor code to use enum of cache result
- add file_name_digest
- rename cache miss to empty cache entry
- rename related function
- WIP reference_graph_builder
- Revert "WIP reference_graph_builder"
- remove commented out process_file
- remove comment
