### PR TITLE
Fix issue with default packwerk.yml contents not properly loading if packwerk.yml does not exist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.41"
+version = "0.1.42"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs/raw_configuration.rs
+++ b/src/packs/raw_configuration.rs
@@ -107,3 +107,18 @@ fn default_cache() -> bool {
 fn default_cache_directory() -> String {
     String::from("tmp/cache/packwerk")
 }
+
+// Add a test that the default RawConfiguration tmp directory is tmp/cache/packwerk
+// Add a test that the default RawConfiguration cache is true
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_defaults() {
+        let raw_configuration = RawConfiguration::default();
+
+        assert_eq!(raw_configuration.cache, true);
+        assert_eq!(raw_configuration.cache_directory, "tmp/cache/packwerk");
+    }
+}

--- a/src/packs/raw_configuration.rs
+++ b/src/packs/raw_configuration.rs
@@ -41,7 +41,7 @@ pub(crate) fn get(absolute_root: &Path) -> RawConfiguration {
 }
 // See: Setting up the configuration file
 // https://github.com/Shopify/packwerk/blob/main/USAGE.md#setting-up-the-configuration-file
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct RawConfiguration {
     // List of patterns for folder paths to include
     #[serde(default = "default_include")]
@@ -78,6 +78,28 @@ pub(crate) struct RawConfiguration {
     // Experimental parser
     #[serde(default)]
     pub experimental_parser: bool,
+}
+
+// We used to use #[derive(Default)] on the RawConfiguration.
+// However, that doesn't use the defaults fed to serde.
+// Ideally, there is a way to generate this Default implementation without having to
+// respecify these.
+// This is used if there is no packwerk.yml. The serde defaults are used if there is one,
+// but a key is not set.
+impl Default for RawConfiguration {
+    fn default() -> Self {
+        RawConfiguration {
+            include: default_include(),
+            exclude: default_exclude(),
+            package_paths: default_package_paths(),
+            custom_associations: default_custom_associations(),
+            cache: default_cache(),
+            cache_directory: default_cache_directory(),
+            autoload_paths: Default::default(),
+            architecture_layers: Default::default(),
+            experimental_parser: Default::default(),
+        }
+    }
 }
 
 fn default_include() -> Vec<String> {
@@ -118,7 +140,7 @@ mod tests {
     fn test_defaults() {
         let raw_configuration = RawConfiguration::default();
 
-        assert_eq!(raw_configuration.cache, true);
+        assert!(raw_configuration.cache);
         assert_eq!(raw_configuration.cache_directory, "tmp/cache/packwerk");
     }
 }

--- a/src/packs/walk_directory.rs
+++ b/src/packs/walk_directory.rs
@@ -221,14 +221,9 @@ mod tests {
         let contains_bad_file = included_files.contains(&node_module_file);
         assert!(!contains_bad_file);
 
-        // Although `node_modules/**/*` should probably exclude `node_modules/file.rb`,
-        // it skips the first files in the directory. For now this doesn't affect behavior,
-        // in Gusto's monolith, so keeping as an open bug for now.
-        // To fix this bug, start by changing this test to:
-        // assert!(!contains_bad_file); (instead of assert!(contains_bad_file);)
         let node_module_file = absolute_path.join("node_modules/file.rb");
         let contains_bad_file = included_files.contains(&node_module_file);
-        assert!(contains_bad_file);
+        assert!(!contains_bad_file);
 
         Ok(())
     }

--- a/tests/fixtures/simple_app/node_modules/subfolder/file.rb
+++ b/tests/fixtures/simple_app/node_modules/subfolder/file.rb
@@ -1,0 +1,1 @@
+# some ignored file


### PR DESCRIPTION
A user reported a really nasty bug where `delete-cache` deleted the current directory if there is no `packwerk.yml` file.

The reason for this is that if there is no `packwerk.yml` file, the rust implementation uses the derived "default" implementation of  the `RawConfiguration` struct. The default implementation of the string for `cache_directory` is an empty string (similarly, if it were a `PathBuf`, it'd be an empty path but).

I had thought that the derived property for `Default` would respect the defaults set by serde, but turns out that's not the case...!

# Commits
- write failing test
- Fix test
