### PR TITLE
Naming updates to ConstantResolver

### DIFF
--- a/src/packs.rs
+++ b/src/packs.rs
@@ -93,7 +93,7 @@ pub(crate) fn list_definitions(configuration: &Configuration) {
     };
 
     let constants = constant_resolver
-        .fully_qualified_constant_to_constant_map
+        .fully_qualified_constant_name_to_constant_definition_map
         .values();
 
     for constant in constants {

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -79,10 +79,7 @@ pub(crate) fn list_definitions(configuration: &Configuration) {
             true,
         );
 
-        get_experimental_constant_resolver(
-            &configuration.absolute_root,
-            &processed_files,
-        )
+        get_experimental_constant_resolver(&processed_files)
     } else {
         get_zeitwerk_constant_resolver(
             &configuration.pack_set,

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -30,7 +30,7 @@ pub(crate) use package_todo::PackageTodo;
 
 use self::caching::create_cache_dir_idempotently;
 
-use self::parsing::Definition;
+use self::parsing::ParsedDefinition;
 use self::parsing::UnresolvedReference;
 
 pub fn greet() {
@@ -58,7 +58,7 @@ pub fn delete_cache(configuration: Configuration) {
 pub struct ProcessedFile {
     pub absolute_path: PathBuf,
     pub unresolved_references: Vec<UnresolvedReference>,
-    pub definitions: Vec<Definition>,
+    pub definitions: Vec<ParsedDefinition>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Default, Eq)]

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -243,10 +243,7 @@ fn get_all_violations(
     );
 
     let constant_resolver = if configuration.experimental_parser {
-        get_experimental_constant_resolver(
-            &configuration.absolute_root,
-            &processed_files,
-        )
+        get_experimental_constant_resolver(&processed_files)
     } else {
         get_zeitwerk_constant_resolver(
             &configuration.pack_set,

--- a/src/packs/parsing.rs
+++ b/src/packs/parsing.rs
@@ -66,7 +66,7 @@ pub struct Range {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Eq)]
-pub struct Definition {
+pub struct ParsedDefinition {
     pub fully_qualified_name: String,
     pub location: Range,
 }

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -40,7 +40,7 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::packs::parsing::ruby::experimental::parser::process_from_contents;
-    use crate::packs::parsing::{Definition, Range};
+    use crate::packs::parsing::{ParsedDefinition, Range};
     use crate::packs::{ProcessedFile, UnresolvedReference};
     use pretty_assertions::assert_eq;
 
@@ -189,7 +189,7 @@ end
         let absolute_path = PathBuf::from("path/to/file.rb");
         let unresolved_references = vec![];
 
-        let definitions = vec![Definition {
+        let definitions = vec![ParsedDefinition {
             fully_qualified_name: String::from("Foo"),
             location: Range {
                 start_row: 1,

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
 use crate::packs::ProcessedFile;
@@ -11,7 +9,6 @@ use super::packwerk::constant_resolver::{
 pub(crate) mod parser;
 
 pub fn get_experimental_constant_resolver(
-    absolute_root: &Path,
     processed_files: &Vec<ProcessedFile>,
 ) -> ConstantResolver {
     let constants = processed_files
@@ -34,7 +31,7 @@ pub fn get_experimental_constant_resolver(
         })
         .collect::<Vec<ConstantDefinition>>();
 
-    ConstantResolver::create(absolute_root, constants, false)
+    ConstantResolver::create(constants, false)
 }
 
 #[cfg(test)]

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -4,7 +4,9 @@ use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
 use crate::packs::ProcessedFile;
 
-use super::packwerk::constant_resolver::{Constant, ConstantResolver};
+use super::packwerk::constant_resolver::{
+    ConstantDefinition, ConstantResolver,
+};
 
 pub(crate) mod parser;
 
@@ -21,16 +23,16 @@ pub fn get_experimental_constant_resolver(
                 .map(|definition| {
                     let fully_qualified_name =
                         definition.fully_qualified_name.to_owned();
-                    Constant {
+                    ConstantDefinition {
                         fully_qualified_name,
                         absolute_path_of_definition: processed_file
                             .absolute_path
                             .to_owned(),
                     }
                 })
-                .collect::<Vec<Constant>>()
+                .collect::<Vec<ConstantDefinition>>()
         })
-        .collect::<Vec<Constant>>();
+        .collect::<Vec<ConstantDefinition>>();
 
     ConstantResolver::create(absolute_root, constants, false)
 }

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -1,6 +1,6 @@
 use crate::packs::{
     inflector_shim::to_class_case,
-    parsing::{Definition, Range, UnresolvedReference},
+    parsing::{ParsedDefinition, Range, UnresolvedReference},
     ProcessedFile,
 };
 use lib_ruby_parser::{
@@ -11,7 +11,7 @@ use std::{collections::HashSet, fs, path::Path};
 
 struct ReferenceCollector<'a> {
     pub references: Vec<UnresolvedReference>,
-    pub definitions: Vec<Definition>,
+    pub definitions: Vec<ParsedDefinition>,
     pub current_namespaces: Vec<String>,
     pub line_col_lookup: LineColLookup<'a>,
     pub behavioral_change_in_namespace: bool,
@@ -79,7 +79,7 @@ fn get_definition_from(
     current_nesting: &String,
     parent_nesting: &[String],
     location: &Range,
-) -> Definition {
+) -> ParsedDefinition {
     let name = current_nesting.to_owned();
 
     let owned_namespace_path: Vec<String> = parent_nesting.to_vec();
@@ -92,7 +92,7 @@ fn get_definition_from(
         name
     };
 
-    Definition {
+    ParsedDefinition {
         fully_qualified_name,
         location: location.to_owned(),
     }
@@ -244,7 +244,7 @@ impl<'a> Visitor for ReferenceCollector<'a> {
             name
         };
 
-        self.definitions.push(Definition {
+        self.definitions.push(ParsedDefinition {
             fully_qualified_name,
             location: loc_to_range(&node.expression_l, &self.line_col_lookup),
         });

--- a/src/packs/parsing/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parsing/ruby/packwerk/constant_resolver.rs
@@ -1,10 +1,7 @@
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Default, Debug)]
 pub struct ConstantResolver {
@@ -18,10 +15,8 @@ pub struct ConstantDefinition {
     pub absolute_path_of_definition: PathBuf,
 }
 
-#[allow(unused_variables)]
 impl ConstantResolver {
     pub fn create(
-        absolute_root: &Path,
         constants: Vec<ConstantDefinition>,
         disallow_multiple_definitions: bool,
     ) -> ConstantResolver {

--- a/src/packs/parsing/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parsing/ruby/packwerk/constant_resolver.rs
@@ -8,11 +8,12 @@ use std::{
 
 #[derive(Default, Debug)]
 pub struct ConstantResolver {
-    pub fully_qualified_constant_to_constant_map: HashMap<String, Constant>,
+    pub fully_qualified_constant_to_constant_map:
+        HashMap<String, ConstantDefinition>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct Constant {
+pub struct ConstantDefinition {
     pub fully_qualified_name: String,
     pub absolute_path_of_definition: PathBuf,
 }
@@ -21,7 +22,7 @@ pub struct Constant {
 impl ConstantResolver {
     pub fn create(
         absolute_root: &Path,
-        constants: Vec<Constant>,
+        constants: Vec<ConstantDefinition>,
         disallow_multiple_definitions: bool,
     ) -> ConstantResolver {
         debug!("Building constant resolver");
@@ -30,7 +31,7 @@ impl ConstantResolver {
 
         let mut fully_qualified_constant_to_constant_map: HashMap<
             String,
-            Constant,
+            ConstantDefinition,
         > = HashMap::new();
 
         // TODO: Do this in parallel?
@@ -71,7 +72,7 @@ impl ConstantResolver {
         &self,
         fully_or_partially_qualified_constant: &str,
         namespace_path: &[&str],
-    ) -> Option<Constant> {
+    ) -> Option<ConstantDefinition> {
         // If the fully_or_partially_qualified_constant is prefixed with ::, the namespace path is technically empty, since it's a global reference
         let (namespace_path, const_name) =
             if fully_or_partially_qualified_constant.starts_with("::") {
@@ -90,7 +91,7 @@ impl ConstantResolver {
         const_name: &'a str,
         current_namespace_path: &'a [&str],
         original_name: &'a str,
-    ) -> Option<Constant> {
+    ) -> Option<ConstantDefinition> {
         let constant = self.resolve_traversing_namespace_path(
             const_name,
             current_namespace_path,
@@ -103,7 +104,7 @@ impl ConstantResolver {
                 let fully_qualified_name_guess =
                     fully_qualified_name_vec.join("::");
 
-                Some(Constant {
+                Some(ConstantDefinition {
                     fully_qualified_name: fully_qualified_name_guess,
                     absolute_path_of_definition: absolute_path_of_definition
                         .to_owned(),
@@ -185,7 +186,7 @@ impl ConstantResolver {
     fn constant_for_fully_qualified_name(
         &self,
         fully_qualified_name: &String,
-    ) -> Option<&Constant> {
+    ) -> Option<&ConstantDefinition> {
         if let Some(constant) = self
             .fully_qualified_constant_to_constant_map
             .get(fully_qualified_name)

--- a/src/packs/parsing/ruby/packwerk/constant_resolver.rs
+++ b/src/packs/parsing/ruby/packwerk/constant_resolver.rs
@@ -8,7 +8,7 @@ use std::{
 
 #[derive(Default, Debug)]
 pub struct ConstantResolver {
-    pub fully_qualified_constant_to_constant_map:
+    pub fully_qualified_constant_name_to_constant_definition_map:
         HashMap<String, ConstantDefinition>,
 }
 
@@ -64,7 +64,8 @@ impl ConstantResolver {
         debug!("Finished building constant resolver");
 
         ConstantResolver {
-            fully_qualified_constant_to_constant_map,
+            fully_qualified_constant_name_to_constant_definition_map:
+                fully_qualified_constant_to_constant_map,
         }
     }
 
@@ -188,7 +189,7 @@ impl ConstantResolver {
         fully_qualified_name: &String,
     ) -> Option<&ConstantDefinition> {
         if let Some(constant) = self
-            .fully_qualified_constant_to_constant_map
+            .fully_qualified_constant_name_to_constant_definition_map
             .get(fully_qualified_name)
         {
             return Some(constant);

--- a/src/packs/parsing/ruby/packwerk/parser.rs
+++ b/src/packs/parsing/ruby/packwerk/parser.rs
@@ -1,6 +1,6 @@
 use crate::packs::{
     inflector_shim::to_class_case,
-    parsing::{Definition, Range, UnresolvedReference},
+    parsing::{ParsedDefinition, Range, UnresolvedReference},
     ProcessedFile,
 };
 use lib_ruby_parser::{
@@ -43,7 +43,7 @@ impl UnresolvedReference {
 
 struct ReferenceCollector<'a> {
     pub references: Vec<UnresolvedReference>,
-    pub definitions: Vec<Definition>,
+    pub definitions: Vec<ParsedDefinition>,
     pub current_namespaces: Vec<String>,
     pub line_col_lookup: LineColLookup<'a>,
     pub in_superclass: bool,
@@ -112,7 +112,7 @@ fn get_definition_from(
     current_nesting: &String,
     parent_nesting: &[String],
     location: &Range,
-) -> Definition {
+) -> ParsedDefinition {
     let name = current_nesting.to_owned();
 
     let owned_namespace_path: Vec<String> = parent_nesting.to_vec();
@@ -125,7 +125,7 @@ fn get_definition_from(
         format!("::{}", name)
     };
 
-    Definition {
+    ParsedDefinition {
         fully_qualified_name,
         location: location.to_owned(),
     }
@@ -284,7 +284,7 @@ impl<'a> Visitor for ReferenceCollector<'a> {
             format!("::{}", name)
         };
 
-        self.definitions.push(Definition {
+        self.definitions.push(ParsedDefinition {
             fully_qualified_name,
             location: loc_to_range(&node.expression_l, &self.line_col_lookup),
         });

--- a/src/packs/parsing/ruby/zeitwerk_utils.rs
+++ b/src/packs/parsing/ruby/zeitwerk_utils.rs
@@ -28,7 +28,7 @@ pub fn get_zeitwerk_constant_resolver(
         cache_dir,
         cache_disabled,
     );
-    ConstantResolver::create(absolute_root, constants, true)
+    ConstantResolver::create(constants, true)
 }
 
 fn inferred_constants_from_pack_set(

--- a/src/packs/parsing/ruby/zeitwerk_utils.rs
+++ b/src/packs/parsing/ruby/zeitwerk_utils.rs
@@ -377,8 +377,8 @@ mod tests {
             &configuration.cache_directory,
             !configuration.cache_enabled,
         );
-        let actual_constant_map =
-            constant_resolver.fully_qualified_constant_to_constant_map;
+        let actual_constant_map = constant_resolver
+            .fully_qualified_constant_name_to_constant_definition_map;
 
         let mut expected_constant_map = HashMap::new();
         expected_constant_map.insert(

--- a/src/packs/per_file_cache.rs
+++ b/src/packs/per_file_cache.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use super::caching::Cache;
 use super::caching::CacheResult;
 use super::caching::EmptyCacheEntry;
-use super::parsing::Definition;
+use super::parsing::ParsedDefinition;
 use super::parsing::Range;
 use super::{ProcessedFile, UnresolvedReference};
 
@@ -101,7 +101,7 @@ pub struct CacheEntry {
     pub file_contents_digest: String,
     pub unresolved_references: Vec<ReferenceEntry>,
     #[serde(default)]
-    pub definitions: Vec<Definition>,
+    pub definitions: Vec<ParsedDefinition>,
 }
 
 impl CacheEntry {


### PR DESCRIPTION
- Rename Definition to ParsedDefinition
- rename constant to ConstantDefinition
- rename constant resolver attribute
- remove unused parameter
