### PR TITLE
Extract out common methods in AST parsing

### DIFF
--- a/src/packs/parsing/ruby/constant_resolver.rs
+++ b/src/packs/parsing/ruby/constant_resolver.rs
@@ -70,8 +70,11 @@ impl ConstantResolver {
         // If the fully_or_partially_qualified_constant is prefixed with ::, the namespace path is technically empty, since it's a global reference
         let (namespace_path, const_name) =
             if fully_or_partially_qualified_constant.starts_with("::") {
+                // `resolve_constant` will add a leading :: before it makes a guess at the fully qualified name
+                // so we remove it here and represent it as a relative constant with no namespace path
                 let const_name = fully_or_partially_qualified_constant
-                    .trim_start_matches("::");
+                    .strip_prefix("::")
+                    .unwrap();
                 let namespace_path: &[&str] = &[];
                 (namespace_path, const_name)
             } else {
@@ -167,6 +170,9 @@ impl ConstantResolver {
 
         let fully_qualified_name_guess =
             fully_qualified_name_guess_vec.join("::");
+
+        let fully_qualified_name_guess =
+            format!("::{}", fully_qualified_name_guess);
 
         if let Some(constant) =
             self.constant_for_fully_qualified_name(&fully_qualified_name_guess)

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -18,6 +18,11 @@ pub fn get_experimental_constant_resolver(
                 .map(|definition| {
                     let fully_qualified_name =
                         definition.fully_qualified_name.to_owned();
+                    // The parser does not (but maybe should) add a leading "::" to the
+                    // definitions, since the convention is to represent fully qualified constant names
+                    // with a leading "::". Eventually we can push this responsibility into the parser.
+                    // let fully_qualified_name =
+                    //     format!("::{}", fully_qualified_name);
                     ConstantDefinition {
                         fully_qualified_name,
                         absolute_path_of_definition: processed_file
@@ -187,7 +192,7 @@ end
         let unresolved_references = vec![];
 
         let definitions = vec![ParsedDefinition {
-            fully_qualified_name: String::from("Foo"),
+            fully_qualified_name: String::from("::Foo"),
             location: Range {
                 start_row: 1,
                 start_col: 6,

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -91,9 +91,9 @@ impl<'a> Visitor for ReferenceCollector<'a> {
         let fully_qualified_name = if !self.current_namespaces.is_empty() {
             let mut name_components = self.current_namespaces.clone();
             name_components.push(name);
-            name_components.join("::")
+            format!("::{}", name_components.join("::"))
         } else {
-            name
+            format!("::{}", name)
         };
 
         self.definitions.push(ParsedDefinition {

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -1,7 +1,10 @@
 use crate::packs::{
     inflector_shim::to_class_case,
     parsing::{
-        ruby::parse_utils::{fetch_node_location, loc_to_range, ParseError},
+        ruby::parse_utils::{
+            fetch_const_const_name, fetch_const_name, fetch_node_location,
+            loc_to_range, ParseError,
+        },
         ParsedDefinition, Range, UnresolvedReference,
     },
     ProcessedFile,
@@ -18,34 +21,6 @@ struct ReferenceCollector<'a> {
     pub current_namespaces: Vec<String>,
     pub line_col_lookup: LineColLookup<'a>,
     pub behavioral_change_in_namespace: bool,
-}
-
-fn fetch_const_name(node: &nodes::Node) -> Result<String, ParseError> {
-    match node {
-        Node::Const(const_node) => Ok(fetch_const_const_name(const_node)?),
-        Node::Cbase(_) => Ok(String::from("")),
-        Node::Send(_) => Err(ParseError::Metaprogramming),
-        Node::Lvar(_) => Err(ParseError::Metaprogramming),
-        Node::Ivar(_) => Err(ParseError::Metaprogramming),
-        Node::Self_(_) => Err(ParseError::Metaprogramming),
-        node => {
-            dbg!(node);
-            panic!(
-                "Cannot handle other node in get_constant_node_name: {:?}",
-                node
-            )
-        }
-    }
-}
-
-fn fetch_const_const_name(node: &nodes::Const) -> Result<String, ParseError> {
-    match &node.scope {
-        Some(s) => {
-            let parent_namespace = fetch_const_name(s)?;
-            Ok(format!("{}::{}", parent_namespace, node.name))
-        }
-        None => Ok(node.name.to_owned()),
-    }
 }
 
 fn get_definition_from(

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -1,6 +1,9 @@
 use crate::packs::{
     inflector_shim::to_class_case,
-    parsing::{ParsedDefinition, Range, UnresolvedReference},
+    parsing::{
+        ruby::parse_utils::{fetch_node_location, ParseError},
+        ParsedDefinition, Range, UnresolvedReference,
+    },
     ProcessedFile,
 };
 use lib_ruby_parser::{
@@ -15,25 +18,6 @@ struct ReferenceCollector<'a> {
     pub current_namespaces: Vec<String>,
     pub line_col_lookup: LineColLookup<'a>,
     pub behavioral_change_in_namespace: bool,
-}
-
-#[derive(Debug)]
-enum ParseError {
-    Metaprogramming,
-    // Add more variants as needed for different error cases
-}
-
-fn fetch_node_location(node: &nodes::Node) -> Result<&Loc, ParseError> {
-    match node {
-        Node::Const(const_node) => Ok(&const_node.expression_l),
-        node => {
-            dbg!(node);
-            panic!(
-                "Cannot handle other node in get_constant_node_name: {:?}",
-                node
-            )
-        }
-    }
 }
 
 fn loc_to_range(loc: &Loc, lookup: &LineColLookup) -> Range {

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -1,13 +1,13 @@
 use crate::packs::{
     inflector_shim::to_class_case,
     parsing::{
-        ruby::parse_utils::{fetch_node_location, ParseError},
+        ruby::parse_utils::{fetch_node_location, loc_to_range, ParseError},
         ParsedDefinition, Range, UnresolvedReference,
     },
     ProcessedFile,
 };
 use lib_ruby_parser::{
-    nodes, traverse::visitor::Visitor, Loc, Node, Parser, ParserOptions,
+    nodes, traverse::visitor::Visitor, Node, Parser, ParserOptions,
 };
 use line_col::LineColLookup;
 use std::{collections::HashSet, fs, path::Path};
@@ -20,17 +20,6 @@ struct ReferenceCollector<'a> {
     pub behavioral_change_in_namespace: bool,
 }
 
-fn loc_to_range(loc: &Loc, lookup: &LineColLookup) -> Range {
-    let (start_row, start_col) = lookup.get(loc.begin); // There's an off-by-one difference here with packwerk
-    let (end_row, end_col) = lookup.get(loc.end);
-
-    Range {
-        start_row,
-        start_col: start_col - 1,
-        end_row,
-        end_col,
-    }
-}
 fn fetch_const_name(node: &nodes::Node) -> Result<String, ParseError> {
     match node {
         Node::Const(const_node) => Ok(fetch_const_const_name(const_node)?),

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -2,8 +2,8 @@ use crate::packs::{
     inflector_shim::to_class_case,
     parsing::{
         ruby::parse_utils::{
-            fetch_const_const_name, fetch_const_name, fetch_node_location,
-            get_definition_from, loc_to_range, ParseError,
+            fetch_casgn_name, fetch_const_const_name, fetch_const_name,
+            fetch_node_location, get_definition_from, loc_to_range,
         },
         ParsedDefinition, UnresolvedReference,
     },
@@ -21,17 +21,6 @@ struct ReferenceCollector<'a> {
     pub current_namespaces: Vec<String>,
     pub line_col_lookup: LineColLookup<'a>,
     pub behavioral_change_in_namespace: bool,
-}
-
-// TODO: Combine with fetch_const_const_name
-fn fetch_casgn_name(node: &nodes::Casgn) -> Result<String, ParseError> {
-    match &node.scope {
-        Some(s) => {
-            let parent_namespace = fetch_const_name(s)?;
-            Ok(format!("{}::{}", parent_namespace, node.name))
-        }
-        None => Ok(node.name.to_owned()),
-    }
 }
 
 fn extract_class_name_from_kwargs(kwargs: &nodes::Kwargs) -> Option<String> {

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -1,9 +1,9 @@
 use crate::packs::{
-    inflector_shim::to_class_case,
     parsing::{
         ruby::parse_utils::{
             fetch_casgn_name, fetch_const_const_name, fetch_const_name,
-            fetch_node_location, get_definition_from, loc_to_range,
+            fetch_node_location, get_definition_from,
+            get_reference_from_active_record_association, loc_to_range,
         },
         ParsedDefinition, UnresolvedReference,
     },
@@ -13,7 +13,7 @@ use lib_ruby_parser::{
     nodes, traverse::visitor::Visitor, Node, Parser, ParserOptions,
 };
 use line_col::LineColLookup;
-use std::{collections::HashSet, fs, path::Path};
+use std::{fs, path::Path};
 
 struct ReferenceCollector<'a> {
     pub references: Vec<UnresolvedReference>,
@@ -21,22 +21,6 @@ struct ReferenceCollector<'a> {
     pub current_namespaces: Vec<String>,
     pub line_col_lookup: LineColLookup<'a>,
     pub behavioral_change_in_namespace: bool,
-}
-
-fn extract_class_name_from_kwargs(kwargs: &nodes::Kwargs) -> Option<String> {
-    for pair_node in kwargs.pairs.iter() {
-        if let Node::Pair(pair) = pair_node {
-            if let Node::Sym(k) = *pair.key.to_owned() {
-                if k.name.to_string_lossy() == *"class_name" {
-                    if let Node::Str(v) = *pair.value.to_owned() {
-                        return Some(v.value.to_string_lossy());
-                    }
-                }
-            }
-        }
-    }
-
-    None
 }
 
 impl<'a> Visitor for ReferenceCollector<'a> {
@@ -82,61 +66,15 @@ impl<'a> Visitor for ReferenceCollector<'a> {
     }
 
     fn on_send(&mut self, node: &nodes::Send) {
-        self.behavioral_change_in_namespace = true;
+        let association_reference =
+            get_reference_from_active_record_association(
+                node,
+                &self.current_namespaces,
+                &self.line_col_lookup,
+            );
 
-        // TODO: Read in args, process associations as a separate class
-        // These can get complicated! e.g. we can specify a class name
-        // dbg!(&node);
-        if node.method_name == *"has_one"
-            || node.method_name == *"has_many"
-            || node.method_name == *"belongs_to"
-            || node.method_name == *"has_and_belongs_to_many"
-        {
-            let first_arg: Option<&Node> = node.args.get(0);
-
-            let mut name: Option<String> = None;
-            for node in node.args.iter() {
-                if let Node::Kwargs(kwargs) = node {
-                    if let Some(found) = extract_class_name_from_kwargs(kwargs)
-                    {
-                        name = Some(found);
-                    }
-                }
-            }
-
-            if let Some(Node::Sym(d)) = first_arg {
-                if name.is_none() {
-                    // We singularize here because by convention Rails will singularize the class name as declared via a symbol,
-                    // e.g. `has_many :companies` will look for a class named `Company`, not `Companies`
-                    name = Some(to_class_case(
-                        &d.name.to_string_lossy(),
-                        true,
-                        &HashSet::new(), // todo: pass in acronyms here
-                    ));
-                }
-            }
-
-            // let unwrapped_name = name.unwrap_or_else(|| {
-            //     panic!("Could not find class name for association {:?}", &node,)
-            // });
-            // Later we should probably handle these cases!
-            if name.is_some() {
-                let unwrapped_name = name.unwrap_or_else(|| {
-                    panic!(
-                        "Could not find class name for association {:?}",
-                        &node,
-                    )
-                });
-
-                self.references.push(UnresolvedReference {
-                    name: unwrapped_name,
-                    namespace_path: self.current_namespaces.to_owned(),
-                    location: loc_to_range(
-                        &node.expression_l,
-                        &self.line_col_lookup,
-                    ),
-                })
-            }
+        if let Some(association_reference) = association_reference {
+            self.references.push(association_reference);
         }
 
         lib_ruby_parser::traverse::visitor::visit_send(self, node);

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -35,9 +35,9 @@ fn get_definition_from(
     let fully_qualified_name = if !owned_namespace_path.is_empty() {
         let mut name_components = owned_namespace_path;
         name_components.push(name);
-        name_components.join("::")
+        format!("::{}", name_components.join("::"))
     } else {
-        name
+        format!("::{}", name)
     };
 
     ParsedDefinition {

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -1,8 +1,8 @@
 use crate::packs::{
     parsing::{
         ruby::parse_utils::{
-            fetch_casgn_name, fetch_const_const_name, fetch_const_name,
-            fetch_node_location, get_definition_from,
+            fetch_const_const_name, fetch_const_name, fetch_node_location,
+            get_constant_assignment_definition, get_definition_from,
             get_reference_from_active_record_association, loc_to_range,
         },
         ParsedDefinition, UnresolvedReference,
@@ -81,25 +81,15 @@ impl<'a> Visitor for ReferenceCollector<'a> {
     }
 
     fn on_casgn(&mut self, node: &nodes::Casgn) {
-        let name_result = fetch_casgn_name(node);
-        if name_result.is_err() {
-            return;
+        let definition = get_constant_assignment_definition(
+            node,
+            self.current_namespaces.to_owned(),
+            &self.line_col_lookup,
+        );
+
+        if let Some(definition) = definition {
+            self.definitions.push(definition);
         }
-
-        // TODO: This can be extracted from on_class
-        let name = name_result.unwrap();
-        let fully_qualified_name = if !self.current_namespaces.is_empty() {
-            let mut name_components = self.current_namespaces.clone();
-            name_components.push(name);
-            format!("::{}", name_components.join("::"))
-        } else {
-            format!("::{}", name)
-        };
-
-        self.definitions.push(ParsedDefinition {
-            fully_qualified_name,
-            location: loc_to_range(&node.expression_l, &self.line_col_lookup),
-        });
 
         if let Some(v) = node.value.to_owned() {
             self.visit(&v);

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -3,9 +3,9 @@ use crate::packs::{
     parsing::{
         ruby::parse_utils::{
             fetch_const_const_name, fetch_const_name, fetch_node_location,
-            loc_to_range, ParseError,
+            get_definition_from, loc_to_range, ParseError,
         },
-        ParsedDefinition, Range, UnresolvedReference,
+        ParsedDefinition, UnresolvedReference,
     },
     ProcessedFile,
 };
@@ -21,29 +21,6 @@ struct ReferenceCollector<'a> {
     pub current_namespaces: Vec<String>,
     pub line_col_lookup: LineColLookup<'a>,
     pub behavioral_change_in_namespace: bool,
-}
-
-fn get_definition_from(
-    current_nesting: &String,
-    parent_nesting: &[String],
-    location: &Range,
-) -> ParsedDefinition {
-    let name = current_nesting.to_owned();
-
-    let owned_namespace_path: Vec<String> = parent_nesting.to_vec();
-
-    let fully_qualified_name = if !owned_namespace_path.is_empty() {
-        let mut name_components = owned_namespace_path;
-        name_components.push(name);
-        format!("::{}", name_components.join("::"))
-    } else {
-        format!("::{}", name)
-    };
-
-    ParsedDefinition {
-        fully_qualified_name,
-        location: location.to_owned(),
-    }
 }
 
 // TODO: Combine with fetch_const_const_name

--- a/src/packs/parsing/ruby/mod.rs
+++ b/src/packs/parsing/ruby/mod.rs
@@ -2,6 +2,7 @@ pub mod constant_resolver;
 pub mod experimental;
 pub mod namespace_calculator;
 pub mod packwerk;
+pub mod parse_utils;
 pub(crate) mod rails_utils;
 pub mod ruby_utils;
 pub mod zeitwerk_utils;

--- a/src/packs/parsing/ruby/packwerk/parser.rs
+++ b/src/packs/parsing/ruby/packwerk/parser.rs
@@ -1,13 +1,13 @@
 use crate::packs::{
     inflector_shim::to_class_case,
     parsing::{
-        ruby::parse_utils::{fetch_node_location, ParseError},
+        ruby::parse_utils::{fetch_node_location, loc_to_range, ParseError},
         ParsedDefinition, Range, UnresolvedReference,
     },
     ProcessedFile,
 };
 use lib_ruby_parser::{
-    nodes, traverse::visitor::Visitor, Loc, Node, Parser, ParserOptions,
+    nodes, traverse::visitor::Visitor, Node, Parser, ParserOptions,
 };
 use line_col::LineColLookup;
 use serde::{Deserialize, Serialize};
@@ -53,17 +53,6 @@ struct ReferenceCollector<'a> {
     pub superclasses: Vec<SuperclassReference>,
 }
 
-fn loc_to_range(loc: &Loc, lookup: &LineColLookup) -> Range {
-    let (start_row, start_col) = lookup.get(loc.begin); // There's an off-by-one difference here with packwerk
-    let (end_row, end_col) = lookup.get(loc.end);
-
-    Range {
-        start_row,
-        start_col: start_col - 1,
-        end_row,
-        end_col,
-    }
-}
 fn fetch_const_name(node: &nodes::Node) -> Result<String, ParseError> {
     match node {
         Node::Const(const_node) => Ok(fetch_const_const_name(const_node)?),

--- a/src/packs/parsing/ruby/packwerk/parser.rs
+++ b/src/packs/parsing/ruby/packwerk/parser.rs
@@ -3,7 +3,7 @@ use crate::packs::{
     parsing::{
         ruby::parse_utils::{
             fetch_const_const_name, fetch_const_name, fetch_node_location,
-            loc_to_range, ParseError,
+            get_definition_from, loc_to_range, ParseError,
         },
         ParsedDefinition, Range, UnresolvedReference,
     },
@@ -54,29 +54,6 @@ struct ReferenceCollector<'a> {
     pub line_col_lookup: LineColLookup<'a>,
     pub in_superclass: bool,
     pub superclasses: Vec<SuperclassReference>,
-}
-
-fn get_definition_from(
-    current_nesting: &String,
-    parent_nesting: &[String],
-    location: &Range,
-) -> ParsedDefinition {
-    let name = current_nesting.to_owned();
-
-    let owned_namespace_path: Vec<String> = parent_nesting.to_vec();
-
-    let fully_qualified_name = if !owned_namespace_path.is_empty() {
-        let mut name_components = owned_namespace_path;
-        name_components.push(name);
-        format!("::{}", name_components.join("::"))
-    } else {
-        format!("::{}", name)
-    };
-
-    ParsedDefinition {
-        fully_qualified_name,
-        location: location.to_owned(),
-    }
 }
 
 // TODO: Combine with fetch_const_const_name

--- a/src/packs/parsing/ruby/packwerk/parser.rs
+++ b/src/packs/parsing/ruby/packwerk/parser.rs
@@ -1,6 +1,9 @@
 use crate::packs::{
     inflector_shim::to_class_case,
-    parsing::{ParsedDefinition, Range, UnresolvedReference},
+    parsing::{
+        ruby::parse_utils::{fetch_node_location, ParseError},
+        ParsedDefinition, Range, UnresolvedReference,
+    },
     ProcessedFile,
 };
 use lib_ruby_parser::{
@@ -48,25 +51,6 @@ struct ReferenceCollector<'a> {
     pub line_col_lookup: LineColLookup<'a>,
     pub in_superclass: bool,
     pub superclasses: Vec<SuperclassReference>,
-}
-
-#[derive(Debug)]
-enum ParseError {
-    Metaprogramming,
-    // Add more variants as needed for different error cases
-}
-
-fn fetch_node_location(node: &nodes::Node) -> Result<&Loc, ParseError> {
-    match node {
-        Node::Const(const_node) => Ok(&const_node.expression_l),
-        node => {
-            dbg!(node);
-            panic!(
-                "Cannot handle other node in get_constant_node_name: {:?}",
-                node
-            )
-        }
-    }
 }
 
 fn loc_to_range(loc: &Loc, lookup: &LineColLookup) -> Range {

--- a/src/packs/parsing/ruby/packwerk/parser.rs
+++ b/src/packs/parsing/ruby/packwerk/parser.rs
@@ -42,7 +42,6 @@ impl UnresolvedReference {
         possible_constants
     }
 }
-
 struct ReferenceCollector<'a> {
     pub references: Vec<UnresolvedReference>,
     pub definitions: Vec<ParsedDefinition>,

--- a/src/packs/parsing/ruby/packwerk/parser.rs
+++ b/src/packs/parsing/ruby/packwerk/parser.rs
@@ -64,7 +64,6 @@ impl<'a> Visitor for ReferenceCollector<'a> {
         let namespace = namespace_result.unwrap();
 
         if let Some(inner) = node.superclass.as_ref() {
-            // dbg!("Visiting superclass!: {:?}", inner);
             self.in_superclass = true;
             self.visit(inner);
             self.in_superclass = false;

--- a/src/packs/parsing/ruby/packwerk/parser.rs
+++ b/src/packs/parsing/ruby/packwerk/parser.rs
@@ -2,8 +2,8 @@ use crate::packs::{
     inflector_shim::to_class_case,
     parsing::{
         ruby::parse_utils::{
-            fetch_const_const_name, fetch_const_name, fetch_node_location,
-            get_definition_from, loc_to_range, ParseError,
+            fetch_casgn_name, fetch_const_const_name, fetch_const_name,
+            fetch_node_location, get_definition_from, loc_to_range,
         },
         ParsedDefinition, Range, UnresolvedReference,
     },
@@ -54,17 +54,6 @@ struct ReferenceCollector<'a> {
     pub line_col_lookup: LineColLookup<'a>,
     pub in_superclass: bool,
     pub superclasses: Vec<SuperclassReference>,
-}
-
-// TODO: Combine with fetch_const_const_name
-fn fetch_casgn_name(node: &nodes::Casgn) -> Result<String, ParseError> {
-    match &node.scope {
-        Some(s) => {
-            let parent_namespace = fetch_const_name(s)?;
-            Ok(format!("{}::{}", parent_namespace, node.name))
-        }
-        None => Ok(node.name.to_owned()),
-    }
 }
 
 fn extract_class_name_from_kwargs(kwargs: &nodes::Kwargs) -> Option<String> {

--- a/src/packs/parsing/ruby/parse_utils.rs
+++ b/src/packs/parsing/ruby/parse_utils.rs
@@ -86,3 +86,14 @@ pub fn fetch_const_const_name(
         None => Ok(node.name.to_owned()),
     }
 }
+
+// TODO: Combine with fetch_const_const_name
+pub fn fetch_casgn_name(node: &nodes::Casgn) -> Result<String, ParseError> {
+    match &node.scope {
+        Some(s) => {
+            let parent_namespace = fetch_const_name(s)?;
+            Ok(format!("{}::{}", parent_namespace, node.name))
+        }
+        None => Ok(node.name.to_owned()),
+    }
+}

--- a/src/packs/parsing/ruby/parse_utils.rs
+++ b/src/packs/parsing/ruby/parse_utils.rs
@@ -187,7 +187,6 @@ pub fn get_constant_assignment_definition(
         return None;
     }
 
-    // TODO: This can be extracted from on_class
     let name = name_result.unwrap();
     let fully_qualified_name = if !current_namespaces.is_empty() {
         let mut name_components = current_namespaces;

--- a/src/packs/parsing/ruby/parse_utils.rs
+++ b/src/packs/parsing/ruby/parse_utils.rs
@@ -1,7 +1,7 @@
 use lib_ruby_parser::{nodes, Loc, Node};
 use line_col::LineColLookup;
 
-use crate::packs::parsing::Range;
+use crate::packs::parsing::{ParsedDefinition, Range};
 
 #[derive(Debug)]
 pub enum ParseError {
@@ -19,6 +19,29 @@ pub fn fetch_node_location(node: &nodes::Node) -> Result<&Loc, ParseError> {
                 node
             )
         }
+    }
+}
+
+pub fn get_definition_from(
+    current_nesting: &String,
+    parent_nesting: &[String],
+    location: &Range,
+) -> ParsedDefinition {
+    let name = current_nesting.to_owned();
+
+    let owned_namespace_path: Vec<String> = parent_nesting.to_vec();
+
+    let fully_qualified_name = if !owned_namespace_path.is_empty() {
+        let mut name_components = owned_namespace_path;
+        name_components.push(name);
+        format!("::{}", name_components.join("::"))
+    } else {
+        format!("::{}", name)
+    };
+
+    ParsedDefinition {
+        fully_qualified_name,
+        location: location.to_owned(),
     }
 }
 

--- a/src/packs/parsing/ruby/parse_utils.rs
+++ b/src/packs/parsing/ruby/parse_utils.rs
@@ -18,7 +18,6 @@ pub fn fetch_node_location(node: &nodes::Node) -> Result<&Loc, ParseError> {
     match node {
         Node::Const(const_node) => Ok(&const_node.expression_l),
         node => {
-            dbg!(node);
             panic!(
                 "Cannot handle other node in get_constant_node_name: {:?}",
                 node
@@ -71,7 +70,6 @@ pub fn fetch_const_name(node: &nodes::Node) -> Result<String, ParseError> {
         Node::Ivar(_) => Err(ParseError::Metaprogramming),
         Node::Self_(_) => Err(ParseError::Metaprogramming),
         node => {
-            dbg!(node);
             panic!(
                 "Cannot handle other node in get_constant_node_name: {:?}",
                 node
@@ -110,7 +108,6 @@ pub fn get_reference_from_active_record_association(
 ) -> Option<UnresolvedReference> {
     // TODO: Read in args, process associations as a separate class
     // These can get complicated! e.g. we can specify a class name
-    // dbg!(&node);
     if node.method_name == *"has_one"
         || node.method_name == *"has_many"
         || node.method_name == *"belongs_to"

--- a/src/packs/parsing/ruby/parse_utils.rs
+++ b/src/packs/parsing/ruby/parse_utils.rs
@@ -1,4 +1,7 @@
 use lib_ruby_parser::{nodes, Loc, Node};
+use line_col::LineColLookup;
+
+use crate::packs::parsing::Range;
 
 #[derive(Debug)]
 pub enum ParseError {
@@ -16,5 +19,17 @@ pub fn fetch_node_location(node: &nodes::Node) -> Result<&Loc, ParseError> {
                 node
             )
         }
+    }
+}
+
+pub fn loc_to_range(loc: &Loc, lookup: &LineColLookup) -> Range {
+    let (start_row, start_col) = lookup.get(loc.begin); // There's an off-by-one difference here with packwerk
+    let (end_row, end_col) = lookup.get(loc.end);
+
+    Range {
+        start_row,
+        start_col: start_col - 1,
+        end_row,
+        end_col,
     }
 }

--- a/src/packs/parsing/ruby/parse_utils.rs
+++ b/src/packs/parsing/ruby/parse_utils.rs
@@ -33,3 +33,33 @@ pub fn loc_to_range(loc: &Loc, lookup: &LineColLookup) -> Range {
         end_col,
     }
 }
+
+pub fn fetch_const_name(node: &nodes::Node) -> Result<String, ParseError> {
+    match node {
+        Node::Const(const_node) => Ok(fetch_const_const_name(const_node)?),
+        Node::Cbase(_) => Ok(String::from("")),
+        Node::Send(_) => Err(ParseError::Metaprogramming),
+        Node::Lvar(_) => Err(ParseError::Metaprogramming),
+        Node::Ivar(_) => Err(ParseError::Metaprogramming),
+        Node::Self_(_) => Err(ParseError::Metaprogramming),
+        node => {
+            dbg!(node);
+            panic!(
+                "Cannot handle other node in get_constant_node_name: {:?}",
+                node
+            )
+        }
+    }
+}
+
+pub fn fetch_const_const_name(
+    node: &nodes::Const,
+) -> Result<String, ParseError> {
+    match &node.scope {
+        Some(s) => {
+            let parent_namespace = fetch_const_name(s)?;
+            Ok(format!("{}::{}", parent_namespace, node.name))
+        }
+        None => Ok(node.name.to_owned()),
+    }
+}

--- a/src/packs/parsing/ruby/parse_utils.rs
+++ b/src/packs/parsing/ruby/parse_utils.rs
@@ -1,0 +1,20 @@
+use lib_ruby_parser::{nodes, Loc, Node};
+
+#[derive(Debug)]
+pub enum ParseError {
+    Metaprogramming,
+    // Add more variants as needed for different error cases
+}
+
+pub fn fetch_node_location(node: &nodes::Node) -> Result<&Loc, ParseError> {
+    match node {
+        Node::Const(const_node) => Ok(&const_node.expression_l),
+        node => {
+            dbg!(node);
+            panic!(
+                "Cannot handle other node in get_constant_node_name: {:?}",
+                node
+            )
+        }
+    }
+}

--- a/src/packs/parsing/ruby/zeitwerk_utils.rs
+++ b/src/packs/parsing/ruby/zeitwerk_utils.rs
@@ -301,7 +301,6 @@ mod tests {
         let absolute_root = get_absolute_root(SIMPLE_APP);
         let resolver = get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP);
 
-        dbg!(&resolver);
         assert_eq!(
             ConstantDefinition {
                 fully_qualified_name: "::Bar".to_string(),

--- a/src/packs/parsing/ruby/zeitwerk_utils.rs
+++ b/src/packs/parsing/ruby/zeitwerk_utils.rs
@@ -140,12 +140,14 @@ fn inferred_constant_from_file(
     let relative_path = relative_path.with_extension("");
 
     let relative_path_str = relative_path.to_str().unwrap();
-    let fully_qualified_constant_name =
+    let camelized_path =
         crate::packs::inflector_shim::camelize(relative_path_str, acronyms);
+    let fully_qualified_name = format!("::{}", camelized_path);
 
+    let absolute_path_of_definition = absolute_path.to_path_buf();
     ConstantDefinition {
-        fully_qualified_name: fully_qualified_constant_name,
-        absolute_path_of_definition: absolute_path.to_path_buf(),
+        fully_qualified_name,
+        absolute_path_of_definition,
     }
 }
 
@@ -299,6 +301,7 @@ mod tests {
         let absolute_root = get_absolute_root(SIMPLE_APP);
         let resolver = get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP);
 
+        dbg!(&resolver);
         assert_eq!(
             ConstantDefinition {
                 fully_qualified_name: "::Bar".to_string(),
@@ -379,50 +382,50 @@ mod tests {
 
         let mut expected_constant_map = HashMap::new();
         expected_constant_map.insert(
-            String::from("Foo::Bar"),
+            String::from("::Foo::Bar"),
             ConstantDefinition {
-                fully_qualified_name: "Foo::Bar".to_owned(),
+                fully_qualified_name: "::Foo::Bar".to_owned(),
                 absolute_path_of_definition: absolute_root
                     .join("packs/foo/app/services/foo/bar.rb"),
             },
         );
 
         expected_constant_map.insert(
-            "Bar".to_owned(),
+            "::Bar".to_owned(),
             ConstantDefinition {
-                fully_qualified_name: "Bar".to_owned(),
+                fully_qualified_name: "::Bar".to_owned(),
                 absolute_path_of_definition: absolute_root
                     .join("packs/bar/app/services/bar.rb"),
             },
         );
         expected_constant_map.insert(
-            "Baz".to_owned(),
+            "::Baz".to_owned(),
             ConstantDefinition {
-                fully_qualified_name: "Baz".to_owned(),
+                fully_qualified_name: "::Baz".to_owned(),
                 absolute_path_of_definition: absolute_root
                     .join("packs/baz/app/services/baz.rb"),
             },
         );
         expected_constant_map.insert(
-            "Foo".to_owned(),
+            "::Foo".to_owned(),
             ConstantDefinition {
-                fully_qualified_name: "Foo".to_owned(),
+                fully_qualified_name: "::Foo".to_owned(),
                 absolute_path_of_definition: absolute_root
                     .join("packs/foo/app/services/foo.rb"),
             },
         );
         expected_constant_map.insert(
-            "SomeConcern".to_owned(),
+            "::SomeConcern".to_owned(),
             ConstantDefinition {
-                fully_qualified_name: "SomeConcern".to_owned(),
+                fully_qualified_name: "::SomeConcern".to_owned(),
                 absolute_path_of_definition: absolute_root
                     .join("packs/bar/app/models/concerns/some_concern.rb"),
             },
         );
         expected_constant_map.insert(
-            "SomeRootClass".to_owned(),
+            "::SomeRootClass".to_owned(),
             ConstantDefinition {
-                fully_qualified_name: "SomeRootClass".to_owned(),
+                fully_qualified_name: "::SomeRootClass".to_owned(),
                 absolute_path_of_definition: absolute_root
                     .join("app/services/some_root_class.rb"),
             },


### PR DESCRIPTION
- fetch_node_location
- loc_to_range
- fetch_const_name
- Make constant definitions inserted by each parser have consistent leading colons
- move get_definition_from in
- fetch_casgn_name
- move out get_reference_from_active_record_association
- remove extra line
- remove debug statement
- fix on_casgn error with experimental parser
- extract out from on_casgn
- remove comment
- remove dbg
- remove dbgs
