### PR TITLE
Allow ConstantResolver to be passed around as a trait to permit multiple implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,7 @@ pub(crate) mod test_util {
 
     use packs::configuration;
 
-    use crate::packs::{
-        self,
-        parsing::ruby::zeitwerk::constant_resolver::ZeitwerkConstantResolver,
-    };
+    use crate::packs::{self, constant_resolver::ConstantResolver};
 
     pub const SIMPLE_APP: &str = "tests/fixtures/simple_app";
 
@@ -20,7 +17,7 @@ pub(crate) mod test_util {
 
     pub fn get_zeitwerk_constant_resolver_for_fixture(
         fixture_name: &str,
-    ) -> ZeitwerkConstantResolver {
+    ) -> Box<dyn ConstantResolver> {
         let absolute_root = get_absolute_root(fixture_name);
         let configuration = configuration::get(&absolute_root);
 

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -88,7 +88,7 @@ pub(crate) fn list_definitions(configuration: &Configuration) {
     };
 
     let constants = constant_resolver
-        .fully_qualified_constant_name_to_constant_definition_map
+        .fully_qualified_constant_name_to_constant_definition_map()
         .values();
 
     for constant in constants {

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 pub(crate) mod caching;
 pub(crate) mod checker;
 pub mod cli;
+pub(crate) mod constant_resolver;
 pub(crate) mod file_utils;
 pub mod logger;
 mod pack_set;

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -62,11 +62,11 @@ impl<'a> Reference<'a> {
             .map(|s| s.as_str())
             .collect::<Vec<&str>>();
 
-        let maybe_constant = constant_resolver
+        let maybe_constant_definition = constant_resolver
             .resolve(&unresolved_reference.name, &str_namespace_path);
 
         let (defining_pack, relative_defining_file, constant_name) =
-            if let Some(constant) = &maybe_constant {
+            if let Some(constant) = &maybe_constant_definition {
                 let absolute_path_of_definition =
                     &constant.absolute_path_of_definition;
                 let relative_defining_file = absolute_path_of_definition

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -52,7 +52,7 @@ pub struct Reference<'a> {
 impl<'a> Reference<'a> {
     fn from_unresolved_reference(
         configuration: &'a Configuration,
-        constant_resolver: &'a Box<dyn ConstantResolver + Send + Sync>,
+        constant_resolver: &'a (dyn ConstantResolver + Send + Sync),
         unresolved_reference: &UnresolvedReference,
         referencing_file_path: &Path,
     ) -> Reference<'a> {
@@ -266,7 +266,7 @@ fn get_all_violations(
                         processed_file.absolute_path.clone();
                     Reference::from_unresolved_reference(
                         configuration,
-                        &constant_resolver,
+                        constant_resolver.as_ref(),
                         unresolved_ref,
                         &absolute_path_of_referring_file,
                     )

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -6,18 +6,15 @@ use crate::packs::parsing::ruby::zeitwerk::get_zeitwerk_constant_resolver;
 
 use crate::packs::Configuration;
 use crate::packs::ProcessedFile;
-use crate::packs::SourceLocation;
+
 use rayon::prelude::IntoParallelIterator;
 use rayon::prelude::IntoParallelRefIterator;
 use rayon::prelude::ParallelIterator;
-use std::path::Path;
+
 use std::{collections::HashSet, path::PathBuf};
 use tracing::debug;
 
 use super::caching::Cache;
-use super::constant_resolver::ConstantResolver;
-
-use super::UnresolvedReference;
 
 pub mod architecture;
 pub mod dependency;
@@ -40,83 +37,6 @@ pub struct ViolationIdentifier {
 pub struct Violation {
     message: String,
     pub identifier: ViolationIdentifier,
-}
-
-impl<'a> Reference<'a> {
-    fn from_unresolved_reference(
-        configuration: &'a Configuration,
-        constant_resolver: &'a (dyn ConstantResolver + Send + Sync),
-        unresolved_reference: &UnresolvedReference,
-        referencing_file_path: &Path,
-    ) -> Reference<'a> {
-        let referencing_pack = configuration
-            .pack_set
-            .for_file(referencing_file_path)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Could not find pack for referencing file path: {}",
-                    &referencing_file_path.display()
-                )
-            });
-
-        let loc = &unresolved_reference.location;
-        let source_location = SourceLocation {
-            line: loc.start_row,
-            column: loc.start_col,
-        };
-
-        let relative_referencing_file_path = referencing_file_path
-            .strip_prefix(&configuration.absolute_root)
-            .unwrap()
-            .to_path_buf();
-
-        let relative_referencing_file =
-            relative_referencing_file_path.to_str().unwrap().to_string();
-
-        let str_namespace_path: Vec<&str> = unresolved_reference
-            .namespace_path
-            .iter()
-            .map(|s| s.as_str())
-            .collect::<Vec<&str>>();
-
-        let maybe_constant_definition = constant_resolver
-            .resolve(&unresolved_reference.name, &str_namespace_path);
-
-        let (defining_pack, relative_defining_file, constant_name) =
-            if let Some(constant) = &maybe_constant_definition {
-                let absolute_path_of_definition =
-                    &constant.absolute_path_of_definition;
-                let relative_defining_file = absolute_path_of_definition
-                    .strip_prefix(&configuration.absolute_root)
-                    .unwrap()
-                    .to_path_buf()
-                    .to_str()
-                    .unwrap()
-                    .to_string();
-
-                let defining_pack = configuration
-                    .pack_set
-                    .for_file(absolute_path_of_definition);
-
-                (
-                    defining_pack,
-                    Some(relative_defining_file),
-                    constant.fully_qualified_name.clone(),
-                )
-            } else {
-                // Contant name is not known, so we'll just use the unresolved name for now
-                (None, None, unresolved_reference.name.clone())
-            };
-
-        Reference {
-            constant_name,
-            defining_pack,
-            referencing_pack,
-            relative_referencing_file,
-            source_location,
-            relative_defining_file,
-        }
-    }
 }
 
 pub(crate) trait CheckerInterface {

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -16,7 +16,6 @@ use tracing::debug;
 
 use super::caching::Cache;
 use super::constant_resolver::ConstantResolver;
-use super::pack::Pack;
 
 use super::UnresolvedReference;
 
@@ -24,6 +23,9 @@ pub mod architecture;
 pub mod dependency;
 pub mod privacy;
 pub mod visibility;
+
+pub(crate) mod reference;
+use reference::Reference;
 
 #[derive(PartialEq, Eq, Hash, Debug)]
 pub struct ViolationIdentifier {
@@ -38,16 +40,6 @@ pub struct ViolationIdentifier {
 pub struct Violation {
     message: String,
     pub identifier: ViolationIdentifier,
-}
-
-#[derive(Debug)]
-pub struct Reference<'a> {
-    constant_name: String,
-    defining_pack: Option<&'a Pack>,
-    relative_defining_file: Option<String>,
-    referencing_pack: &'a Pack,
-    relative_referencing_file: String,
-    source_location: SourceLocation,
 }
 
 impl<'a> Reference<'a> {

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -170,7 +170,7 @@ fn get_all_violations(
             let references: Vec<Reference> = processed_file
                 .unresolved_references
                 .iter()
-                .map(|unresolved_ref| {
+                .flat_map(|unresolved_ref| {
                     let absolute_path_of_referring_file =
                         processed_file.absolute_path.clone();
                     Reference::from_unresolved_reference(

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -65,33 +65,31 @@ impl<'a> Reference<'a> {
         let maybe_constant = constant_resolver
             .resolve(&unresolved_reference.name, &str_namespace_path);
 
-        let (defining_pack, relative_defining_file) = if let Some(constant) =
-            &maybe_constant
-        {
-            let absolute_path_of_definition =
-                &constant.absolute_path_of_definition;
-            let relative_defining_file = absolute_path_of_definition
-                .strip_prefix(&configuration.absolute_root)
-                .unwrap()
-                .to_path_buf()
-                .to_str()
-                .unwrap()
-                .to_string();
+        let (defining_pack, relative_defining_file, constant_name) =
+            if let Some(constant) = &maybe_constant {
+                let absolute_path_of_definition =
+                    &constant.absolute_path_of_definition;
+                let relative_defining_file = absolute_path_of_definition
+                    .strip_prefix(&configuration.absolute_root)
+                    .unwrap()
+                    .to_path_buf()
+                    .to_str()
+                    .unwrap()
+                    .to_string();
 
-            let defining_pack =
-                configuration.pack_set.for_file(absolute_path_of_definition);
+                let defining_pack = configuration
+                    .pack_set
+                    .for_file(absolute_path_of_definition);
 
-            (defining_pack, Some(relative_defining_file))
-        } else {
-            (None, None)
-        };
-
-        let constant_name = if let Some(constant) = &maybe_constant {
-            &constant.fully_qualified_name
-        } else {
-            // Contant name is not known, so we'll just use the unresolved name for now
-            &unresolved_reference.name
-        };
+                (
+                    defining_pack,
+                    Some(relative_defining_file),
+                    &constant.fully_qualified_name,
+                )
+            } else {
+                // Contant name is not known, so we'll just use the unresolved name for now
+                (None, None, &unresolved_reference.name)
+            };
 
         let constant_name = constant_name.clone();
 

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -105,7 +105,7 @@ impl<'a> Reference<'a> {
                 )
             });
 
-        let loc = unresolved_reference.location.clone();
+        let loc = &unresolved_reference.location;
         let source_location = SourceLocation {
             line: loc.start_row,
             column: loc.start_col,

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -15,8 +15,9 @@ use std::{collections::HashSet, path::PathBuf};
 use tracing::debug;
 
 use super::caching::Cache;
+use super::constant_resolver::ConstantResolver;
 use super::pack::Pack;
-use super::parsing::ruby::zeitwerk::constant_resolver::ZeitwerkConstantResolver;
+
 use super::UnresolvedReference;
 
 pub mod architecture;
@@ -51,7 +52,7 @@ pub struct Reference<'a> {
 impl<'a> Reference<'a> {
     fn from_unresolved_reference(
         configuration: &'a Configuration,
-        constant_resolver: &'a ZeitwerkConstantResolver,
+        constant_resolver: &'a Box<dyn ConstantResolver + Send + Sync>,
         unresolved_reference: &UnresolvedReference,
         referencing_file_path: &Path,
     ) -> Reference<'a> {

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -49,6 +49,7 @@ pub struct Reference<'a> {
     relative_referencing_file: String,
     source_location: SourceLocation,
 }
+
 impl<'a> Reference<'a> {
     fn from_unresolved_reference(
         configuration: &'a Configuration,

--- a/src/packs/checker/reference.rs
+++ b/src/packs/checker/reference.rs
@@ -1,0 +1,11 @@
+use crate::packs::{pack::Pack, SourceLocation};
+
+#[derive(Debug)]
+pub struct Reference<'a> {
+    pub constant_name: String,
+    pub defining_pack: Option<&'a Pack>,
+    pub relative_defining_file: Option<String>,
+    pub referencing_pack: &'a Pack,
+    pub relative_referencing_file: String,
+    pub source_location: SourceLocation,
+}

--- a/src/packs/checker/reference.rs
+++ b/src/packs/checker/reference.rs
@@ -55,42 +55,45 @@ impl<'a> Reference<'a> {
         let maybe_constant_definition = constant_resolver
             .resolve(&unresolved_reference.name, &str_namespace_path);
 
-        let (defining_pack, relative_defining_file, constant_name) =
-            if let Some(constant) = &maybe_constant_definition {
-                let absolute_path_of_definition =
-                    &constant.absolute_path_of_definition;
-                let relative_defining_file = absolute_path_of_definition
-                    .strip_prefix(&configuration.absolute_root)
-                    .unwrap()
-                    .to_path_buf()
-                    .to_str()
-                    .unwrap()
-                    .to_string();
+        if let Some(constant) = &maybe_constant_definition {
+            let absolute_path_of_definition =
+                &constant.absolute_path_of_definition;
+            let relative_defining_file = absolute_path_of_definition
+                .strip_prefix(&configuration.absolute_root)
+                .unwrap()
+                .to_path_buf()
+                .to_str()
+                .unwrap()
+                .to_string();
 
-                let defining_pack = configuration
-                    .pack_set
-                    .for_file(absolute_path_of_definition);
+            let defining_pack =
+                configuration.pack_set.for_file(absolute_path_of_definition);
 
-                let relative_defining_file = Some(relative_defining_file);
-                let constant_name = constant.fully_qualified_name.clone();
+            let relative_defining_file = Some(relative_defining_file);
+            let constant_name = constant.fully_qualified_name.clone();
 
-                (defining_pack, relative_defining_file, constant_name)
-            } else {
-                let defining_pack = None;
-                let relative_defining_file = None;
-                // Contant name is not known, so we'll just use the unresolved name for now
-                let constant_name = unresolved_reference.name.clone();
+            vec![Reference {
+                constant_name,
+                defining_pack,
+                referencing_pack,
+                relative_referencing_file,
+                source_location,
+                relative_defining_file,
+            }]
+        } else {
+            let defining_pack = None;
+            let relative_defining_file = None;
+            // Contant name is not known, so we'll just use the unresolved name for now
+            let constant_name = unresolved_reference.name.clone();
 
-                (defining_pack, relative_defining_file, constant_name)
-            };
-
-        vec![Reference {
-            constant_name,
-            defining_pack,
-            referencing_pack,
-            relative_referencing_file,
-            source_location,
-            relative_defining_file,
-        }]
+            vec![Reference {
+                constant_name,
+                defining_pack,
+                referencing_pack,
+                relative_referencing_file,
+                source_location,
+                relative_defining_file,
+            }]
+        }
     }
 }

--- a/src/packs/checker/reference.rs
+++ b/src/packs/checker/reference.rs
@@ -1,4 +1,9 @@
-use crate::packs::{pack::Pack, SourceLocation};
+use std::path::Path;
+
+use crate::packs::{
+    constant_resolver::ConstantResolver, pack::Pack,
+    parsing::UnresolvedReference, Configuration, SourceLocation,
+};
 
 #[derive(Debug)]
 pub struct Reference<'a> {
@@ -8,4 +13,81 @@ pub struct Reference<'a> {
     pub referencing_pack: &'a Pack,
     pub relative_referencing_file: String,
     pub source_location: SourceLocation,
+}
+
+impl<'a> Reference<'a> {
+    pub fn from_unresolved_reference(
+        configuration: &'a Configuration,
+        constant_resolver: &'a (dyn ConstantResolver + Send + Sync),
+        unresolved_reference: &UnresolvedReference,
+        referencing_file_path: &Path,
+    ) -> Reference<'a> {
+        let referencing_pack = configuration
+            .pack_set
+            .for_file(referencing_file_path)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Could not find pack for referencing file path: {}",
+                    &referencing_file_path.display()
+                )
+            });
+
+        let loc = &unresolved_reference.location;
+        let source_location = SourceLocation {
+            line: loc.start_row,
+            column: loc.start_col,
+        };
+
+        let relative_referencing_file_path = referencing_file_path
+            .strip_prefix(&configuration.absolute_root)
+            .unwrap()
+            .to_path_buf();
+
+        let relative_referencing_file =
+            relative_referencing_file_path.to_str().unwrap().to_string();
+
+        let str_namespace_path: Vec<&str> = unresolved_reference
+            .namespace_path
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<&str>>();
+
+        let maybe_constant_definition = constant_resolver
+            .resolve(&unresolved_reference.name, &str_namespace_path);
+
+        let (defining_pack, relative_defining_file, constant_name) =
+            if let Some(constant) = &maybe_constant_definition {
+                let absolute_path_of_definition =
+                    &constant.absolute_path_of_definition;
+                let relative_defining_file = absolute_path_of_definition
+                    .strip_prefix(&configuration.absolute_root)
+                    .unwrap()
+                    .to_path_buf()
+                    .to_str()
+                    .unwrap()
+                    .to_string();
+
+                let defining_pack = configuration
+                    .pack_set
+                    .for_file(absolute_path_of_definition);
+
+                (
+                    defining_pack,
+                    Some(relative_defining_file),
+                    constant.fully_qualified_name.clone(),
+                )
+            } else {
+                // Contant name is not known, so we'll just use the unresolved name for now
+                (None, None, unresolved_reference.name.clone())
+            };
+
+        Reference {
+            constant_name,
+            defining_pack,
+            referencing_pack,
+            relative_referencing_file,
+            source_location,
+            relative_defining_file,
+        }
+    }
 }

--- a/src/packs/checker/reference.rs
+++ b/src/packs/checker/reference.rs
@@ -71,14 +71,17 @@ impl<'a> Reference<'a> {
                     .pack_set
                     .for_file(absolute_path_of_definition);
 
-                (
-                    defining_pack,
-                    Some(relative_defining_file),
-                    constant.fully_qualified_name.clone(),
-                )
+                let relative_defining_file = Some(relative_defining_file);
+                let constant_name = constant.fully_qualified_name.clone();
+
+                (defining_pack, relative_defining_file, constant_name)
             } else {
+                let defining_pack = None;
+                let relative_defining_file = None;
                 // Contant name is not known, so we'll just use the unresolved name for now
-                (None, None, unresolved_reference.name.clone())
+                let constant_name = unresolved_reference.name.clone();
+
+                (defining_pack, relative_defining_file, constant_name)
             };
 
         vec![Reference {

--- a/src/packs/checker/reference.rs
+++ b/src/packs/checker/reference.rs
@@ -21,7 +21,7 @@ impl<'a> Reference<'a> {
         constant_resolver: &'a (dyn ConstantResolver + Send + Sync),
         unresolved_reference: &UnresolvedReference,
         referencing_file_path: &Path,
-    ) -> Reference<'a> {
+    ) -> Vec<Reference<'a>> {
         let referencing_pack = configuration
             .pack_set
             .for_file(referencing_file_path)
@@ -81,13 +81,13 @@ impl<'a> Reference<'a> {
                 (None, None, unresolved_reference.name.clone())
             };
 
-        Reference {
+        vec![Reference {
             constant_name,
             defining_pack,
             referencing_pack,
             relative_referencing_file,
             source_location,
             relative_defining_file,
-        }
+        }]
     }
 }

--- a/src/packs/constant_resolver.rs
+++ b/src/packs/constant_resolver.rs
@@ -1,4 +1,12 @@
-use super::parsing::ruby::zeitwerk::constant_resolver::ConstantDefinition;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct ConstantDefinition {
+    pub fully_qualified_name: String,
+    pub absolute_path_of_definition: PathBuf,
+}
 
 pub trait ConstantResolver {
     fn resolve(

--- a/src/packs/constant_resolver.rs
+++ b/src/packs/constant_resolver.rs
@@ -1,0 +1,9 @@
+use super::parsing::ruby::zeitwerk::constant_resolver::ConstantDefinition;
+
+pub trait ConstantResolver {
+    fn resolve(
+        &self,
+        fully_or_partially_qualified_constant: &str,
+        namespace_path: &[&str],
+    ) -> Option<ConstantDefinition>;
+}

--- a/src/packs/constant_resolver.rs
+++ b/src/packs/constant_resolver.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -14,4 +14,8 @@ pub trait ConstantResolver {
         fully_or_partially_qualified_constant: &str,
         namespace_path: &[&str],
     ) -> Option<ConstantDefinition>;
+
+    fn fully_qualified_constant_name_to_constant_definition_map(
+        &self,
+    ) -> &HashMap<String, ConstantDefinition>;
 }

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -1,6 +1,9 @@
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-use crate::packs::{constant_resolver::ConstantDefinition, ProcessedFile};
+use crate::packs::{
+    constant_resolver::{ConstantDefinition, ConstantResolver},
+    ProcessedFile,
+};
 
 use super::zeitwerk::constant_resolver::ZeitwerkConstantResolver;
 
@@ -8,7 +11,7 @@ pub(crate) mod parser;
 
 pub fn get_experimental_constant_resolver(
     processed_files: &Vec<ProcessedFile>,
-) -> ZeitwerkConstantResolver {
+) -> Box<dyn ConstantResolver + Send + Sync> {
     let constants = processed_files
         .into_par_iter()
         .flat_map(|processed_file| {

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -1,10 +1,8 @@
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-use crate::packs::ProcessedFile;
+use crate::packs::{constant_resolver::ConstantDefinition, ProcessedFile};
 
-use super::zeitwerk::constant_resolver::{
-    ConstantDefinition, ZeitwerkConstantResolver,
-};
+use super::zeitwerk::constant_resolver::ZeitwerkConstantResolver;
 
 pub(crate) mod parser;
 

--- a/src/packs/parsing/ruby/zeitwerk/constant_resolver.rs
+++ b/src/packs/parsing/ruby/zeitwerk/constant_resolver.rs
@@ -1,20 +1,16 @@
-use serde::{Deserialize, Serialize};
 use tracing::debug;
 
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
 
-use crate::packs::parsing::ruby::namespace_calculator::combine_namespace_with_constant_name;
+use crate::packs::{
+    constant_resolver::ConstantDefinition,
+    parsing::ruby::namespace_calculator::combine_namespace_with_constant_name,
+};
 
 #[derive(Default, Debug)]
 pub struct ZeitwerkConstantResolver {
     pub fully_qualified_constant_name_to_constant_definition_map:
         HashMap<String, ConstantDefinition>,
-}
-
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct ConstantDefinition {
-    pub fully_qualified_name: String,
-    pub absolute_path_of_definition: PathBuf,
 }
 
 impl ZeitwerkConstantResolver {

--- a/src/packs/parsing/ruby/zeitwerk/mod.rs
+++ b/src/packs/parsing/ruby/zeitwerk/mod.rs
@@ -10,11 +10,12 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::packs::{
-    caching::create_cache_dir_idempotently, file_utils::process_glob_pattern,
+    caching::create_cache_dir_idempotently,
+    constant_resolver::ConstantDefinition, file_utils::process_glob_pattern,
     pack::Pack, parsing::ruby::rails_utils::get_acronyms_from_disk, PackSet,
 };
 
-use self::constant_resolver::{ConstantDefinition, ZeitwerkConstantResolver};
+use self::constant_resolver::ZeitwerkConstantResolver;
 
 use super::inflector_shim;
 
@@ -232,10 +233,7 @@ fn get_autoload_paths(packs: &Vec<Pack>) -> Vec<PathBuf> {
 mod tests {
     use super::*;
     use crate::packs;
-    use crate::packs::{
-        configuration,
-        parsing::ruby::zeitwerk::constant_resolver::ConstantDefinition,
-    };
+    use crate::packs::configuration;
 
     fn teardown() {
         packs::delete_cache(configuration::get(&PathBuf::from(

--- a/src/packs/parsing/ruby/zeitwerk/mod.rs
+++ b/src/packs/parsing/ruby/zeitwerk/mod.rs
@@ -11,8 +11,11 @@ use tracing::debug;
 
 use crate::packs::{
     caching::create_cache_dir_idempotently,
-    constant_resolver::ConstantDefinition, file_utils::process_glob_pattern,
-    pack::Pack, parsing::ruby::rails_utils::get_acronyms_from_disk, PackSet,
+    constant_resolver::{ConstantDefinition, ConstantResolver},
+    file_utils::process_glob_pattern,
+    pack::Pack,
+    parsing::ruby::rails_utils::get_acronyms_from_disk,
+    PackSet,
 };
 
 use self::constant_resolver::ZeitwerkConstantResolver;
@@ -24,7 +27,7 @@ pub fn get_zeitwerk_constant_resolver(
     absolute_root: &Path,
     cache_dir: &Path,
     cache_disabled: bool,
-) -> ZeitwerkConstantResolver {
+) -> Box<dyn ConstantResolver + Send + Sync> {
     let constants = inferred_constants_from_pack_set(
         pack_set,
         absolute_root,
@@ -379,7 +382,7 @@ mod tests {
             !configuration.cache_enabled,
         );
         let actual_constant_map = constant_resolver
-            .fully_qualified_constant_name_to_constant_definition_map;
+            .fully_qualified_constant_name_to_constant_definition_map();
 
         let mut expected_constant_map = HashMap::new();
         expected_constant_map.insert(
@@ -431,7 +434,7 @@ mod tests {
                     .join("app/services/some_root_class.rb"),
             },
         );
-        assert_eq!(expected_constant_map, actual_constant_map);
+        assert_eq!(&expected_constant_map, actual_constant_map);
 
         teardown();
     }


### PR DESCRIPTION
- Create constant_resolver trait
- Move ConstantDefinition into constant_resolver module
- separate out the resolve method so it can come from the trait
- attempt to pass around instances of the trait rather than the zeitwerk constant resolver itself
- fix clippy
- do not clone unresolved ref location
- combine conditionals
- update var name
- move things that do not change based on constant resolution to the top
- add line
- mvoe reference into its own module
- move implementation into same module
- make Reference::from_unresolved_reference return an array of references
- refactor method part 1
- refactor method part 2
