### PR TITLE
Remove lifetimes from References so using across threads and closures is simpler

### DIFF
--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -15,6 +15,7 @@ use std::{collections::HashSet, path::PathBuf};
 use tracing::debug;
 
 use super::caching::Cache;
+use super::PackSet;
 
 pub mod architecture;
 pub mod dependency;
@@ -40,7 +41,11 @@ pub struct Violation {
 }
 
 pub(crate) trait CheckerInterface {
-    fn check(&self, reference: &Reference) -> Option<Violation>;
+    fn check(
+        &self,
+        reference: &Reference,
+        configuration: &Configuration,
+    ) -> Option<Violation>;
 }
 
 pub(crate) trait ValidatorInterface {
@@ -203,7 +208,7 @@ fn get_all_violations(
         .flat_map(|c| {
             references
                 .par_iter()
-                .flat_map(|r| c.check(r))
+                .flat_map(|r| c.check(r, configuration))
                 .collect::<Vec<Violation>>()
         })
         .collect();

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -15,7 +15,6 @@ use std::{collections::HashSet, path::PathBuf};
 use tracing::debug;
 
 use super::caching::Cache;
-use super::PackSet;
 
 pub mod architecture;
 pub mod dependency;

--- a/src/packs/checker/architecture.rs
+++ b/src/packs/checker/architecture.rs
@@ -1,6 +1,6 @@
 use super::{CheckerInterface, ViolationIdentifier};
 use crate::packs::checker::Reference;
-use crate::packs::Violation;
+use crate::packs::{Configuration, Violation};
 
 #[derive(Default, Clone)]
 pub struct Layers {
@@ -39,12 +39,19 @@ pub struct Checker {
 }
 
 impl CheckerInterface for Checker {
-    fn check(&self, reference: &Reference) -> Option<Violation> {
-        let referencing_pack = &reference.referencing_pack;
+    fn check(
+        &self,
+        reference: &Reference,
+        configuration: &Configuration,
+    ) -> Option<Violation> {
+        let pack_set = &configuration.pack_set;
+
+        let referencing_pack = &reference.referencing_pack(pack_set);
+
         let relative_defining_file = &reference.relative_defining_file;
 
         let referencing_pack_name = &referencing_pack.name;
-        let defining_pack = &reference.defining_pack;
+        let defining_pack = &reference.defining_pack(pack_set);
         if defining_pack.is_none() {
             return None;
         }
@@ -108,7 +115,7 @@ mod tests {
 
     use crate::packs::{
         pack::{CheckerSetting, Pack},
-        SourceLocation,
+        PackSet, SourceLocation,
     };
 
     use super::*;
@@ -129,10 +136,18 @@ mod tests {
             ..Pack::default()
         };
 
+        let configuration = Configuration {
+            pack_set: PackSet {
+                packs: vec![defining_pack.clone(), referencing_pack.clone()],
+                ..PackSet::default()
+            },
+            ..Configuration::default()
+        };
+
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack: &referencing_pack,
+            defining_pack_name: Some(defining_pack.name),
+            referencing_pack_name: referencing_pack.name,
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -141,7 +156,7 @@ mod tests {
             )),
             source_location: SourceLocation { line: 3, column: 1 },
         };
-        assert_eq!(None, checker.check(&reference))
+        assert_eq!(None, checker.check(&reference, &configuration))
     }
 
     #[test]
@@ -166,10 +181,18 @@ mod tests {
             ..Pack::default()
         };
 
+        let configuration = Configuration {
+            pack_set: PackSet {
+                packs: vec![defining_pack.clone(), referencing_pack.clone()],
+                ..PackSet::default()
+            },
+            ..Configuration::default()
+        };
+
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack: &referencing_pack,
+            defining_pack_name: Some(defining_pack.name),
+            referencing_pack_name: referencing_pack.name,
             relative_referencing_file: String::from(
                 "packs/bar/app/services/bar.rb",
             ),
@@ -189,7 +212,10 @@ mod tests {
                 defining_pack_name: String::from("packs/foo"),
             },
         };
-        assert_eq!(expected_violation, checker.check(&reference).unwrap())
+        assert_eq!(
+            expected_violation,
+            checker.check(&reference, &configuration).unwrap()
+        )
     }
 
     #[test]
@@ -214,10 +240,18 @@ mod tests {
             ..Pack::default()
         };
 
+        let configuration = Configuration {
+            pack_set: PackSet {
+                packs: vec![defining_pack.clone(), referencing_pack.clone()],
+                ..PackSet::default()
+            },
+            ..Configuration::default()
+        };
+
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack: &referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: &referencing_pack,
             relative_referencing_file: String::from(
                 "packs/bar/app/services/bar.rb",
             ),

--- a/src/packs/checker/architecture.rs
+++ b/src/packs/checker/architecture.rs
@@ -113,6 +113,8 @@ impl CheckerInterface for Checker {
 #[cfg(test)]
 mod tests {
 
+    use std::collections::{HashMap, HashSet};
+
     use crate::packs::{
         pack::{CheckerSetting, Pack},
         PackSet, SourceLocation,
@@ -136,18 +138,10 @@ mod tests {
             ..Pack::default()
         };
 
-        let configuration = Configuration {
-            pack_set: PackSet {
-                packs: vec![defining_pack.clone(), referencing_pack.clone()],
-                ..PackSet::default()
-            },
-            ..Configuration::default()
-        };
-
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack_name: Some(defining_pack.name),
-            referencing_pack_name: referencing_pack.name,
+            defining_pack_name: Some(defining_pack.name.to_owned()),
+            referencing_pack_name: referencing_pack.name.to_owned(),
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -155,6 +149,14 @@ mod tests {
                 "packs/bar/app/services/bar.rb",
             )),
             source_location: SourceLocation { line: 3, column: 1 },
+        };
+
+        let configuration = Configuration {
+            pack_set: PackSet::build(
+                HashSet::from_iter(vec![defining_pack, referencing_pack]),
+                HashMap::new(),
+            ),
+            ..Configuration::default()
         };
         assert_eq!(None, checker.check(&reference, &configuration))
     }
@@ -181,18 +183,10 @@ mod tests {
             ..Pack::default()
         };
 
-        let configuration = Configuration {
-            pack_set: PackSet {
-                packs: vec![defining_pack.clone(), referencing_pack.clone()],
-                ..PackSet::default()
-            },
-            ..Configuration::default()
-        };
-
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack_name: Some(defining_pack.name),
-            referencing_pack_name: referencing_pack.name,
+            defining_pack_name: Some(defining_pack.name.to_owned()),
+            referencing_pack_name: referencing_pack.name.to_owned(),
             relative_referencing_file: String::from(
                 "packs/bar/app/services/bar.rb",
             ),
@@ -200,6 +194,14 @@ mod tests {
                 "packs/foo/app/services/foo.rb",
             )),
             source_location: SourceLocation { line: 3, column: 1 },
+        };
+
+        let configuration = Configuration {
+            pack_set: PackSet::build(
+                HashSet::from_iter(vec![defining_pack, referencing_pack]),
+                HashMap::new(),
+            ),
+            ..Configuration::default()
         };
 
         let expected_violation = Violation {
@@ -240,18 +242,10 @@ mod tests {
             ..Pack::default()
         };
 
-        let configuration = Configuration {
-            pack_set: PackSet {
-                packs: vec![defining_pack.clone(), referencing_pack.clone()],
-                ..PackSet::default()
-            },
-            ..Configuration::default()
-        };
-
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack_name: Some(&defining_pack),
-            referencing_pack_name: &referencing_pack,
+            defining_pack_name: Some(defining_pack.name.to_owned()),
+            referencing_pack_name: referencing_pack.name.to_owned(),
             relative_referencing_file: String::from(
                 "packs/bar/app/services/bar.rb",
             ),
@@ -261,6 +255,14 @@ mod tests {
             source_location: SourceLocation { line: 3, column: 1 },
         };
 
-        assert_eq!(None, checker.check(&reference))
+        let configuration = Configuration {
+            pack_set: PackSet::build(
+                HashSet::from_iter(vec![defining_pack, referencing_pack]),
+                HashMap::new(),
+            ),
+            ..Configuration::default()
+        };
+
+        assert_eq!(None, checker.check(&reference, &configuration))
     }
 }

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -79,13 +79,13 @@ The following groups of packages from a cycle:
 // Add test for does not enforce dependencies
 impl CheckerInterface for Checker {
     fn check(&self, reference: &Reference) -> Option<Violation> {
-        let referencing_pack = reference.referencing_pack;
+        let referencing_pack = reference.referencing_pack_name;
         if referencing_pack.enforce_dependencies.is_false() {
             return None;
         }
 
         let referencing_pack_name = &referencing_pack.name;
-        let defining_pack = &reference.defining_pack;
+        let defining_pack = &reference.defining_pack_name;
 
         if defining_pack.is_none() {
             return None;
@@ -165,10 +165,10 @@ mod tests {
         );
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack: Some(
+            defining_pack_name: Some(
                 configuration.pack_set.for_pack(&String::from("packs/foo")),
             ),
-            referencing_pack: configuration
+            referencing_pack_name: configuration
                 .pack_set
                 .for_pack(&String::from("packs/foo")),
             relative_referencing_file: String::from(
@@ -193,10 +193,10 @@ mod tests {
         );
         let reference = Reference {
             constant_name: String::from("::Bar"),
-            defining_pack: Some(
+            defining_pack_name: Some(
                 configuration.pack_set.for_pack(&String::from("packs/bar")),
             ),
-            referencing_pack: configuration
+            referencing_pack_name: configuration
                 .pack_set
                 .for_pack(&String::from("packs/foo")),
             relative_referencing_file: String::from(

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -78,14 +78,20 @@ The following groups of packages from a cycle:
 // TODO: Add test for ignored_dependencies
 // Add test for does not enforce dependencies
 impl CheckerInterface for Checker {
-    fn check(&self, reference: &Reference) -> Option<Violation> {
-        let referencing_pack = reference.referencing_pack_name;
+    fn check(
+        &self,
+        reference: &Reference,
+        configuration: &Configuration,
+    ) -> Option<Violation> {
+        let referencing_pack =
+            reference.referencing_pack(&configuration.pack_set);
+
         if referencing_pack.enforce_dependencies.is_false() {
             return None;
         }
 
         let referencing_pack_name = &referencing_pack.name;
-        let defining_pack = &reference.defining_pack_name;
+        let defining_pack = &reference.defining_pack(&configuration.pack_set);
 
         if defining_pack.is_none() {
             return None;
@@ -165,12 +171,8 @@ mod tests {
         );
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack_name: Some(
-                configuration.pack_set.for_pack(&String::from("packs/foo")),
-            ),
-            referencing_pack_name: configuration
-                .pack_set
-                .for_pack(&String::from("packs/foo")),
+            defining_pack_name: Some(String::from("packs/foo")),
+            referencing_pack_name: String::from("packs/foo"),
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -179,7 +181,7 @@ mod tests {
             )),
             source_location: SourceLocation { line: 3, column: 1 },
         };
-        assert_eq!(None, checker.check(&reference))
+        assert_eq!(None, checker.check(&reference, &configuration))
     }
 
     #[test]
@@ -193,12 +195,8 @@ mod tests {
         );
         let reference = Reference {
             constant_name: String::from("::Bar"),
-            defining_pack_name: Some(
-                configuration.pack_set.for_pack(&String::from("packs/bar")),
-            ),
-            referencing_pack_name: configuration
-                .pack_set
-                .for_pack(&String::from("packs/foo")),
+            defining_pack_name: Some(String::from("packs/bar")),
+            referencing_pack_name: String::from("packs/foo"),
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -218,7 +216,10 @@ mod tests {
                 defining_pack_name: String::from("packs/bar"),
             },
         };
-        assert_eq!(expected_violation, checker.check(&reference).unwrap())
+        assert_eq!(
+            expected_violation,
+            checker.check(&reference, &configuration).unwrap()
+        )
     }
 
     #[test]

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -6,11 +6,11 @@ pub struct Checker {}
 
 impl CheckerInterface for Checker {
     fn check(&self, reference: &Reference) -> Option<Violation> {
-        let referencing_pack = &reference.referencing_pack;
+        let referencing_pack = &reference.referencing_pack_name;
         let relative_defining_file = &reference.relative_defining_file;
 
         let referencing_pack_name = &referencing_pack.name;
-        let defining_pack = &reference.defining_pack;
+        let defining_pack = &reference.defining_pack_name;
         if defining_pack.is_none() {
             return None;
         }
@@ -131,8 +131,8 @@ mod tests {
         };
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: referencing_pack,
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -161,8 +161,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Bar"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: referencing_pack,
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -201,8 +201,8 @@ mod tests {
         };
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack: &referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: &referencing_pack,
             relative_referencing_file: String::from(
                 "packs/bar/app/services/bar.rb",
             ),
@@ -232,8 +232,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Bar"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: referencing_pack,
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -273,8 +273,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Bar"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: referencing_pack,
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -306,8 +306,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Bar"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: referencing_pack,
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -350,8 +350,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Bar::BarChild"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: referencing_pack,
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -394,8 +394,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Bar"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: referencing_pack,
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),

--- a/src/packs/checker/visibility.rs
+++ b/src/packs/checker/visibility.rs
@@ -1,6 +1,6 @@
 use super::{CheckerInterface, ViolationIdentifier};
 use crate::packs::checker::Reference;
-use crate::packs::Violation;
+use crate::packs::{Configuration, Violation};
 
 pub struct Checker {}
 
@@ -8,12 +8,17 @@ pub struct Checker {}
 // Once we implement packs validate, we need to ensure that nothing can add a dependency
 // from a pack to a pack that doesn't permit visibility from the referencing pack
 impl CheckerInterface for Checker {
-    fn check(&self, reference: &Reference) -> Option<Violation> {
-        let referencing_pack = &reference.referencing_pack_name;
+    fn check(
+        &self,
+        reference: &Reference,
+        configuration: &Configuration,
+    ) -> Option<Violation> {
+        let referencing_pack =
+            &reference.referencing_pack(&configuration.pack_set);
         let relative_defining_file = &reference.relative_defining_file;
 
         let referencing_pack_name = &referencing_pack.name;
-        let defining_pack = &reference.defining_pack_name;
+        let defining_pack = &reference.defining_pack(&configuration.pack_set);
         if defining_pack.is_none() {
             return None;
         }
@@ -66,7 +71,7 @@ impl CheckerInterface for Checker {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     use super::*;
     use crate::packs::{
@@ -90,8 +95,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack_name: Some(&defining_pack),
-            referencing_pack_name: &referencing_pack,
+            defining_pack_name: Some(defining_pack.name.to_owned()),
+            referencing_pack_name: referencing_pack.name.to_owned(),
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -100,7 +105,16 @@ mod tests {
             )),
             source_location: SourceLocation { line: 3, column: 1 },
         };
-        assert_eq!(None, checker.check(&reference))
+
+        let configuration = Configuration {
+            pack_set: PackSet::build(
+                HashSet::from_iter(vec![defining_pack, referencing_pack]),
+                HashMap::new(),
+            ),
+            ..Configuration::default()
+        };
+
+        assert_eq!(None, checker.check(&reference, &configuration))
     }
 
     #[test]
@@ -119,8 +133,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack_name: Some(&defining_pack),
-            referencing_pack_name: &referencing_pack,
+            defining_pack_name: Some(defining_pack.name.to_owned()),
+            referencing_pack_name: referencing_pack.name.to_owned(),
             relative_referencing_file: String::from(
                 "packs/bar/app/services/bar.rb",
             ),
@@ -140,7 +154,18 @@ mod tests {
                 defining_pack_name: String::from("packs/foo"),
             },
         };
-        assert_eq!(expected_violation, checker.check(&reference).unwrap())
+
+        let configuration = Configuration {
+            pack_set: PackSet::build(
+                HashSet::from_iter(vec![defining_pack, referencing_pack]),
+                HashMap::new(),
+            ),
+            ..Configuration::default()
+        };
+        assert_eq!(
+            expected_violation,
+            checker.check(&reference, &configuration).unwrap()
+        )
     }
 
     #[test]
@@ -163,8 +188,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack_name: Some(&defining_pack),
-            referencing_pack_name: &referencing_pack,
+            defining_pack_name: Some(defining_pack.name.to_owned()),
+            referencing_pack_name: referencing_pack.name.to_owned(),
             relative_referencing_file: String::from(
                 "packs/bar/app/services/bar.rb",
             ),
@@ -173,7 +198,13 @@ mod tests {
             )),
             source_location: SourceLocation { line: 3, column: 1 },
         };
-
-        assert_eq!(None, checker.check(&reference))
+        let configuration = Configuration {
+            pack_set: PackSet::build(
+                HashSet::from_iter(vec![defining_pack, referencing_pack]),
+                HashMap::new(),
+            ),
+            ..Configuration::default()
+        };
+        assert_eq!(None, checker.check(&reference, &configuration))
     }
 }

--- a/src/packs/checker/visibility.rs
+++ b/src/packs/checker/visibility.rs
@@ -9,11 +9,11 @@ pub struct Checker {}
 // from a pack to a pack that doesn't permit visibility from the referencing pack
 impl CheckerInterface for Checker {
     fn check(&self, reference: &Reference) -> Option<Violation> {
-        let referencing_pack = &reference.referencing_pack;
+        let referencing_pack = &reference.referencing_pack_name;
         let relative_defining_file = &reference.relative_defining_file;
 
         let referencing_pack_name = &referencing_pack.name;
-        let defining_pack = &reference.defining_pack;
+        let defining_pack = &reference.defining_pack_name;
         if defining_pack.is_none() {
             return None;
         }
@@ -90,8 +90,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack: &referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: &referencing_pack,
             relative_referencing_file: String::from(
                 "packs/foo/app/services/foo.rb",
             ),
@@ -119,8 +119,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack: &referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: &referencing_pack,
             relative_referencing_file: String::from(
                 "packs/bar/app/services/bar.rb",
             ),
@@ -163,8 +163,8 @@ mod tests {
 
         let reference = Reference {
             constant_name: String::from("::Foo"),
-            defining_pack: Some(&defining_pack),
-            referencing_pack: &referencing_pack,
+            defining_pack_name: Some(&defining_pack),
+            referencing_pack_name: &referencing_pack,
             relative_referencing_file: String::from(
                 "packs/bar/app/services/bar.rb",
             ),


### PR DESCRIPTION
- wip
- do not use lifetimes on reference
