### PR TITLE
Move cycle detection into validate for now to emulate packwerk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.43"
+version = "0.1.44"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -92,16 +92,6 @@ pub(crate) fn check_all(
         errors_present = true;
     }
 
-    let validation_errors = validate(&configuration);
-    if !validation_errors.is_empty() {
-        errors_present = true;
-
-        println!("{} validation error(s) detected:", validation_errors.len());
-        for validation_error in validation_errors.iter() {
-            println!("{}\n", validation_error);
-        }
-    }
-
     if errors_present {
         Err("Packwerk check failed".into())
     } else {
@@ -123,6 +113,24 @@ fn validate(configuration: &Configuration) -> Vec<String> {
 
     validation_errors
 }
+
+pub(crate) fn validate_all(
+    configuration: &Configuration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let validation_errors = validate(configuration);
+    if !validation_errors.is_empty() {
+        println!("{} validation error(s) detected:", validation_errors.len());
+        for validation_error in validation_errors.iter() {
+            println!("{}\n", validation_error);
+        }
+
+        Err("Packwerk validate failed".into())
+    } else {
+        println!("Packwerk validate succeeded!");
+        Ok(())
+    }
+}
+
 pub(crate) fn update(
     configuration: Configuration,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -64,7 +64,7 @@ impl ValidatorInterface for Checker {
             let error_message = format!(
                 "
 Found {} strongly connected components (i.e. dependency cycles)
-The following groups of packages from a cycle:
+The following groups of packages form a cycle:
 
 {}",
                 sccs.len(),
@@ -236,7 +236,7 @@ mod tests {
         let expected_message = String::from(
             "
 Found 1 strongly connected components (i.e. dependency cycles)
-The following groups of packages from a cycle:
+The following groups of packages form a cycle:
 
 packs/foo, packs/bar",
         );

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -116,7 +116,10 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         Command::Check { files } => checker::check_all(configuration, files),
         Command::Update => checker::update(configuration),
-        Command::Validate => Err("💡 Please use `packs check` to detect dependency cycles and run other configuration validations".into()),
+        Command::Validate => {
+            checker::validate_all(&configuration)
+            // Err("💡 Please use `packs check` to detect dependency cycles and run other configuration validations".into())
+        }
         Command::DeleteCache => {
             packs::delete_cache(configuration);
             Ok(())

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -55,28 +55,3 @@ fn test_check_with_experimental_parser() -> Result<(), Box<dyn Error>> {
     common::teardown();
     Ok(())
 }
-
-#[test]
-fn test_check_cycle_detection() -> Result<(), Box<dyn Error>> {
-    let expected_message = String::from(
-        "
-Found 1 strongly connected components (i.e. dependency cycles)
-The following groups of packages from a cycle:
-
-packs/foo, packs/bar",
-    );
-
-    Command::cargo_bin("packs")
-        .unwrap()
-        .arg("--project-root")
-        .arg("tests/fixtures/app_with_dependency_cycles")
-        .arg("--debug")
-        .arg("check")
-        .assert()
-        .failure()
-        .stdout(predicate::str::contains("1 validation error(s) detected:"))
-        .stdout(predicate::str::contains(expected_message));
-
-    common::teardown();
-    Ok(())
-}

--- a/tests/validate_test.rs
+++ b/tests/validate_test.rs
@@ -1,0 +1,30 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::{error::Error, process::Command};
+
+mod common;
+
+#[test]
+fn test_validate_cycle_detection() -> Result<(), Box<dyn Error>> {
+    let expected_message = String::from(
+        "
+Found 1 strongly connected components (i.e. dependency cycles)
+The following groups of packages form a cycle:
+
+packs/foo, packs/bar",
+    );
+
+    Command::cargo_bin("packs")
+        .unwrap()
+        .arg("--project-root")
+        .arg("tests/fixtures/app_with_dependency_cycles")
+        .arg("--debug")
+        .arg("validate")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("1 validation error(s) detected:"))
+        .stdout(predicate::str::contains(expected_message));
+
+    common::teardown();
+    Ok(())
+}


### PR DESCRIPTION
Perhaps later we can choose one of the following options:

1) Change packwerk to permit a flag to turn cycle detection on or off (`packs check` can respect that flag)
2) Change `packs` to read a flag to turn cycle detection ON (`packs check` would then do cycle detection, although this would diverge from packwerk slightly)

For now, we'll keep things separate to continue to emulate packwerk and make adoption simpler.
