### PR TITLE
Implement check-contents subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.60"
+version = "0.1.61"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Usage: packs [OPTIONS] <COMMAND>
 Commands:
   greet                           Just saying hi
   check                           Look for violations in the codebase
+  check-contents                  Check file contents piped to stdin
   update                          Update package_todo.yml files with the current violations
   validate                        Look for validation errors in the codebase
   check-unnecessary-dependencies  Check for dependencies that when removed produce no violations.

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -1,6 +1,7 @@
 use crate::packs;
 use crate::packs::checker;
 
+use crate::packs::file_utils::get_absolute_path;
 use clap::{Parser, Subcommand};
 use clap_derive::Args;
 use std::path::PathBuf;
@@ -43,6 +44,9 @@ enum Command {
 
     #[clap(about = "Look for violations in the codebase")]
     Check { files: Vec<String> },
+
+    #[clap(about = "Check file contents piped to stdin")]
+    CheckContents { file: String },
 
     #[clap(
         about = "Update package_todo.yml files with the current violations"
@@ -132,6 +136,11 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
         Command::Check { files } => checker::check_all(configuration, files),
+        Command::CheckContents { file } => {
+            let absolute_path = get_absolute_path(file.clone(), &configuration);
+            configuration.stdin_file_path = Some(absolute_path);
+            checker::check_all(configuration, vec![file])
+        }
         Command::Update => checker::update(configuration),
         Command::Validate => {
             checker::validate_all(&configuration)

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -30,6 +30,7 @@ pub struct Configuration {
     pub experimental_parser: bool,
     pub ignored_definitions: HashMap<String, HashSet<PathBuf>>,
     pub custom_associations: Vec<String>,
+    pub stdin_file_path: Option<PathBuf>,
     // Note that it'd probably be better to use the logger library, `tracing` (see logger.rs)
     // and configure logging in one place. As the complexity of how/why we want to see different logs
     // grows, we can refactor this.
@@ -115,6 +116,7 @@ pub(crate) fn from_raw(
 
     debug!("Finished building configuration");
 
+    let stdin_file_path: Option<PathBuf> = None;
     let print_files = false;
 
     Configuration {
@@ -127,6 +129,7 @@ pub(crate) fn from_raw(
         experimental_parser,
         ignored_definitions,
         custom_associations,
+        stdin_file_path,
         print_files,
     }
 }

--- a/src/packs/parsing/erb/experimental/parser.rs
+++ b/src/packs/parsing/erb/experimental/parser.rs
@@ -1,8 +1,9 @@
+use crate::packs::file_utils::file_read_contents;
 use crate::packs::{
     file_utils::convert_erb_to_ruby_without_sourcemaps, parsing::Range,
     Configuration, ProcessedFile, UnresolvedReference,
 };
-use std::{fs, path::Path};
+use std::path::Path;
 
 use crate::packs::parsing::ruby::experimental::parser::process_from_contents as process_from_ruby_contents;
 
@@ -10,10 +11,7 @@ pub(crate) fn process_from_path(
     path: &Path,
     configuration: &Configuration,
 ) -> ProcessedFile {
-    let contents = fs::read_to_string(path).unwrap_or_else(|_| {
-        panic!("Failed to read contents of {}", path.to_string_lossy())
-    });
-
+    let contents = file_read_contents(path, configuration);
     process_from_contents(contents, path, configuration)
 }
 

--- a/src/packs/parsing/erb/packwerk/parser.rs
+++ b/src/packs/parsing/erb/packwerk/parser.rs
@@ -1,8 +1,9 @@
+use crate::packs::file_utils::file_read_contents;
 use crate::packs::{
     file_utils::convert_erb_to_ruby_without_sourcemaps, parsing::Range,
     Configuration, ProcessedFile, UnresolvedReference,
 };
-use std::{fs, path::Path};
+use std::path::Path;
 
 use crate::packs::parsing::ruby::packwerk::parser::process_from_contents as process_from_ruby_contents;
 
@@ -10,10 +11,7 @@ pub(crate) fn process_from_path(
     path: &Path,
     configuration: &Configuration,
 ) -> ProcessedFile {
-    let contents = fs::read_to_string(path).unwrap_or_else(|_| {
-        panic!("Failed to read contents of {}", path.to_string_lossy())
-    });
-
+    let contents = file_read_contents(path, configuration);
     process_from_contents(contents, path, configuration)
 }
 

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -1,3 +1,4 @@
+use crate::packs::file_utils::file_read_contents;
 use crate::packs::{
     parsing::{
         ruby::parse_utils::{
@@ -13,7 +14,7 @@ use lib_ruby_parser::{
     nodes, traverse::visitor::Visitor, Node, Parser, ParserOptions,
 };
 use line_col::LineColLookup;
-use std::{fs, path::Path};
+use std::path::Path;
 
 struct ReferenceCollector<'a> {
     pub references: Vec<UnresolvedReference>,
@@ -169,10 +170,7 @@ pub(crate) fn process_from_path(
     path: &Path,
     configuration: &Configuration,
 ) -> ProcessedFile {
-    let contents = fs::read_to_string(path).unwrap_or_else(|_| {
-        panic!("Failed to read contents of {}", path.to_string_lossy())
-    });
-
+    let contents = file_read_contents(path, configuration);
     process_from_contents(contents, path, configuration)
 }
 

--- a/src/packs/parsing/ruby/packwerk/parser.rs
+++ b/src/packs/parsing/ruby/packwerk/parser.rs
@@ -1,3 +1,4 @@
+use crate::packs::file_utils::file_read_contents;
 use crate::packs::{
     parsing::{
         ruby::{
@@ -17,7 +18,7 @@ use lib_ruby_parser::{
 };
 use line_col::LineColLookup;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fs, path::Path};
+use std::{collections::HashMap, path::Path};
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct SuperclassReference {
@@ -201,10 +202,7 @@ pub(crate) fn process_from_path(
     path: &Path,
     configuration: &Configuration,
 ) -> ProcessedFile {
-    let contents = fs::read_to_string(path).unwrap_or_else(|_| {
-        panic!("Failed to read contents of {}", path.to_string_lossy())
-    });
-
+    let contents = file_read_contents(path, configuration);
     process_from_contents(contents, path, configuration)
 }
 

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -1,6 +1,6 @@
-use assert_cmd::prelude::*;
+use assert_cmd::Command;
 use predicates::prelude::*;
-use std::{error::Error, process::Command};
+use std::{error::Error, fs};
 
 mod common;
 
@@ -147,6 +147,31 @@ fn test_check_with_strict_mode() -> Result<(), Box<dyn Error>> {
         .stdout(predicate::str::contains(
             "packs/foo cannot have dependency violations on packs/bar because strict mode is enabled for dependency violations in the enforcing pack's package.yml file",
         ));
+
+    common::teardown();
+    Ok(())
+}
+
+#[test]
+fn test_check_contents() -> Result<(), Box<dyn Error>> {
+    let relative_path = "packs/foo/app/services/foo.rb";
+    let foo_rb_contents = fs::read_to_string(format!(
+        "tests/fixtures/simple_app/{}",
+        relative_path
+    ))?;
+
+    Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg("tests/fixtures/simple_app")
+        .arg("--debug")
+        .arg("check-contents")
+        .arg(relative_path)
+        .write_stdin(foo_rb_contents)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("2 violation(s) detected:"))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
 
     common::teardown();
     Ok(())

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -166,12 +166,12 @@ fn test_check_contents() -> Result<(), Box<dyn Error>> {
         .arg("--debug")
         .arg("check-contents")
         .arg(relative_path)
-        .write_stdin(foo_rb_contents)
+        .write_stdin(format!("\n\n\n{}", foo_rb_contents))
         .assert()
         .failure()
         .stdout(predicate::str::contains("2 violation(s) detected:"))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:6:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:6:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
 
     common::teardown();
     Ok(())


### PR DESCRIPTION
This PR implements a command that checks file contents piped though standard input. The command also takes a file path so that it knows where the file is supposed to be located and what constraints apply.

The intent is to use this command to implement as-you-type linters in IDEs.

```
$ cat foo/bar.rb | packs check-contents foo/bar.rb
```

This probably needs a test... 😄 Also not sure if cache handling is correct.