### PR TITLE
Implement stale violations detection

### DIFF
--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -58,13 +58,13 @@ pub(crate) fn check_all(
     debug!("Intersecting input files with configuration included files");
     let absolute_paths: HashSet<PathBuf> = configuration.intersect_files(files);
 
-    let violations: HashSet<Violation> =
+    let found_violations: HashSet<Violation> =
         get_all_violations(&configuration, &absolute_paths);
 
     let recorded_violations = &configuration.pack_set.all_violations;
 
     debug!("Filtering out recorded violations");
-    let unrecorded_violations = violations
+    let unrecorded_violations = found_violations
         .iter()
         .filter(|v| !recorded_violations.contains(&v.identifier))
         .collect::<Vec<&Violation>>();
@@ -73,7 +73,7 @@ pub(crate) fn check_all(
 
     debug!("Finding stale violations");
     let violation_identifiers: Vec<&ViolationIdentifier> =
-        violations.par_iter().map(|v| &v.identifier).collect();
+        found_violations.par_iter().map(|v| &v.identifier).collect();
 
     let stale_violations = recorded_violations
         .par_iter()

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -72,12 +72,14 @@ pub(crate) fn check_all(
     debug!("Finished filtering out recorded violations");
 
     debug!("Finding stale violations");
-    let violation_identifiers: HashSet<&ViolationIdentifier> =
+    let found_violation_identifiers: HashSet<&ViolationIdentifier> =
         found_violations.par_iter().map(|v| &v.identifier).collect();
 
     let stale_violations = recorded_violations
         .par_iter()
-        .filter(|v_identifier| !violation_identifiers.contains(v_identifier))
+        .filter(|v_identifier| {
+            !found_violation_identifiers.contains(v_identifier)
+        })
         .collect::<Vec<&ViolationIdentifier>>();
 
     debug!("Finished finding stale violations");

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -72,7 +72,7 @@ pub(crate) fn check_all(
     debug!("Finished filtering out recorded violations");
 
     debug!("Finding stale violations");
-    let violation_identifiers: Vec<&ViolationIdentifier> =
+    let violation_identifiers: HashSet<&ViolationIdentifier> =
         found_violations.par_iter().map(|v| &v.identifier).collect();
 
     let stale_violations = recorded_violations

--- a/src/packs/package_todo.rs
+++ b/src/packs/package_todo.rs
@@ -131,7 +131,7 @@ pub fn package_todos_for_pack_name(
 }
 pub fn write_violations_to_disk(
     configuration: Configuration,
-    violations: Vec<Violation>,
+    violations: HashSet<Violation>,
 ) {
     debug!("Starting writing violations to disk");
     // First we need to group the violations by the repsonsible pack, which today is always the referencing pack

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -55,3 +55,20 @@ fn test_check_with_experimental_parser() -> Result<(), Box<dyn Error>> {
     common::teardown();
     Ok(())
 }
+
+#[test]
+fn test_check_with_stale_violations() -> Result<(), Box<dyn Error>> {
+    Command::cargo_bin("packs")
+        .unwrap()
+        .arg("--project-root")
+        .arg("tests/fixtures/contains_stale_violations")
+        .arg("check")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "There were stale violations found, please run `packs update`",
+        ));
+
+    common::teardown();
+    Ok(())
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -32,3 +32,60 @@ pub fn teardown() {
     //     );
     // }
 }
+
+// In case we want our tests to call `update`
+#[allow(dead_code)]
+pub fn set_up_fixtures() {
+    let contains_stale_violations_bar_todo = String::from("\
+# This file contains a list of dependencies that are not part of the long term plan for the
+# 'packs/foo' package.
+# We should generally work to reduce this list over time.
+#
+# You can regenerate this file using the following command:
+#
+# bin/packwerk update-todo
+---
+packs/foo:
+  \"::Foo\":
+    violations:
+    - dependency
+    - privacy
+    files:
+    - packs/bar/app/services/bar.rb
+
+");
+
+    // Rewrite tests/fixtures/contains_stale_violations/packs/bar/package_todo.yml with the above contents,
+    // whether it is present or not:
+    fs::write(
+        "tests/fixtures/contains_stale_violations/packs/bar/package_todo.yml",
+        contains_stale_violations_bar_todo,
+    )
+    .unwrap();
+
+    let contains_stale_violations_foo_todo = String::from("\
+# This file contains a list of dependencies that are not part of the long term plan for the
+# 'packs/foo' package.
+# We should generally work to reduce this list over time.
+#
+# You can regenerate this file using the following command:
+#
+# bin/packwerk update-todo
+---
+packs/bar:
+  \"::Bar\":
+    violations:
+    - dependency
+    - privacy
+    files:
+    - packs/foo/app/services/foo.rb
+");
+
+    // Rewrite tests/fixtures/contains_stale_violations/packs/bar/package_todo.yml with the above contents,
+    // whether it is present or not:
+    fs::write(
+        "tests/fixtures/contains_stale_violations/packs/foo/package_todo.yml",
+        contains_stale_violations_foo_todo,
+    )
+    .unwrap();
+}

--- a/tests/fixtures/contains_stale_violations/packs/bar/app/services/bar.rb
+++ b/tests/fixtures/contains_stale_violations/packs/bar/app/services/bar.rb
@@ -1,0 +1,2 @@
+module Bar
+end

--- a/tests/fixtures/contains_stale_violations/packs/bar/package.yml
+++ b/tests/fixtures/contains_stale_violations/packs/bar/package.yml
@@ -1,0 +1,1 @@
+enforce_privacy: true

--- a/tests/fixtures/contains_stale_violations/packs/bar/package_todo.yml
+++ b/tests/fixtures/contains_stale_violations/packs/bar/package_todo.yml
@@ -13,3 +13,4 @@ packs/foo:
     - privacy
     files:
     - packs/bar/app/services/bar.rb
+

--- a/tests/fixtures/contains_stale_violations/packs/bar/package_todo.yml
+++ b/tests/fixtures/contains_stale_violations/packs/bar/package_todo.yml
@@ -5,6 +5,7 @@
 # You can regenerate this file using the following command:
 #
 # bin/packwerk update-todo
+---
 packs/foo:
   "::Foo":
     violations:

--- a/tests/fixtures/contains_stale_violations/packs/bar/package_todo.yml
+++ b/tests/fixtures/contains_stale_violations/packs/bar/package_todo.yml
@@ -1,0 +1,14 @@
+# This file contains a list of dependencies that are not part of the long term plan for the
+# 'packs/foo' package.
+# We should generally work to reduce this list over time.
+#
+# You can regenerate this file using the following command:
+#
+# bin/packwerk update-todo
+packs/foo:
+  "::Foo":
+    violations:
+    - dependency
+    - privacy
+    files:
+    - packs/bar/app/services/bar.rb

--- a/tests/fixtures/contains_stale_violations/packs/foo/app/services/foo.rb
+++ b/tests/fixtures/contains_stale_violations/packs/foo/app/services/foo.rb
@@ -1,0 +1,5 @@
+module Foo
+  def calls_bar_with_stated_dependency
+    Bar
+  end
+end

--- a/tests/fixtures/contains_stale_violations/packs/foo/package.yml
+++ b/tests/fixtures/contains_stale_violations/packs/foo/package.yml
@@ -1,0 +1,3 @@
+enforce_dependencies: true
+dependencies:
+  - packs/bar

--- a/tests/fixtures/contains_stale_violations/packs/foo/package_todo.yml
+++ b/tests/fixtures/contains_stale_violations/packs/foo/package_todo.yml
@@ -5,6 +5,7 @@
 # You can regenerate this file using the following command:
 #
 # bin/packwerk update-todo
+---
 packs/bar:
   "::Bar":
     violations:

--- a/tests/fixtures/contains_stale_violations/packs/foo/package_todo.yml
+++ b/tests/fixtures/contains_stale_violations/packs/foo/package_todo.yml
@@ -1,0 +1,14 @@
+# This file contains a list of dependencies that are not part of the long term plan for the
+# 'packs/foo' package.
+# We should generally work to reduce this list over time.
+#
+# You can regenerate this file using the following command:
+#
+# bin/packwerk update-todo
+packs/bar:
+  "::Bar":
+    violations:
+    - dependency
+    - privacy
+    files:
+    - packs/foo/app/services/foo.rb

--- a/tests/fixtures/contains_stale_violations/packwerk.yml
+++ b/tests/fixtures/contains_stale_violations/packwerk.yml
@@ -1,0 +1,23 @@
+# See: Setting up the configuration file
+# https://github.com/Shopify/packwerk/blob/main/USAGE.md#setting-up-the-configuration-file
+
+# List of patterns for folder paths to include
+# include:
+# - "**/*.{rb,rake,erb}"
+
+# List of patterns for folder paths to exclude
+# exclude:
+# - "{bin,node_modules,script,tmp,vendor}/**/*"
+
+# Patterns to find package configuration files
+# package_paths: "**/"
+
+# List of custom associations, if any
+# custom_associations:
+# - "cache_belongs_to"
+
+# Whether or not you want the cache enabled (disabled by default)
+cache: false
+
+# Where you want the cache to be stored (default below)
+# cache_directory: 'tmp/cache/packwerk'


### PR DESCRIPTION
Closes #66 
This also permits the deletion of `package_todo.yml` where the entire file is stale.

# Commits
- Create test fixture
- add failing test
- make test pass
- violations => found_violations
- use a hashset for violation identifiers
- rename var
- write another failing test
- make test pass maybe
- commit update to package todo
