### PR TITLE
Allow custom associations to accept symbols to be compatible with packwerk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.48"
+version = "0.1.49"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"


### PR DESCRIPTION
- Allow custom_associations to accept Ruby symbols as values
- bump version
