### PR TITLE
Fix bug with experimental parser and single file inputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.52"
+version = "0.1.53"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -299,7 +299,7 @@ fn get_all_references(
         let all_processed_files: Vec<ProcessedFile> = process_files_with_cache(
             // The experimental parser needs *all* processed files to get definitions
             &configuration.absolute_root,
-            absolute_paths,
+            &configuration.included_files,
             cache,
             configuration,
         );
@@ -310,7 +310,14 @@ fn get_all_references(
             &configuration.ignored_definitions,
         );
 
-        (constant_resolver, all_processed_files)
+        let processed_files_to_check = all_processed_files
+            .into_iter()
+            .filter(|processed_file| {
+                absolute_paths.contains(&processed_file.absolute_path)
+            })
+            .collect();
+
+        (constant_resolver, processed_files_to_check)
     } else {
         let processed_files: Vec<ProcessedFile> = process_files_with_cache(
             &configuration.absolute_root,

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -22,6 +22,44 @@ fn test_check() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn test_check_with_single_file() -> Result<(), Box<dyn Error>> {
+    Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg("tests/fixtures/simple_app")
+        .arg("--debug")
+        .arg("check")
+        .arg("packs/foo/app/services/foo.rb")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("2 violation(s) detected:"))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
+
+    common::teardown();
+    Ok(())
+}
+
+#[test]
+fn test_check_with_single_file_experimental_parser(
+) -> Result<(), Box<dyn Error>> {
+    Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg("tests/fixtures/simple_app")
+        .arg("--debug")
+        .arg("--experimental-parser")
+        .arg("check")
+        .arg("packs/foo/app/services/foo.rb")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("2 violation(s) detected:"))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
+
+    common::teardown();
+    Ok(())
+}
+
+#[test]
 fn test_check_with_package_todo_file() -> Result<(), Box<dyn Error>> {
     Command::cargo_bin("packs")?
         .arg("--project-root")


### PR DESCRIPTION
There was an issue with the experimental parser where when given single files, it was unable to properly resolve constants.

This is because the experimental parser requires looking at *all* processed files to properly resolve constants.

To fix this, I *always* process all files with the experimental parser, but only analyze references related to the input files.

# Commits
- add failing test
- refactor existing get_all_references function
- fix test
- bump version
