### PR TITLE
Allow packwerk.yml package_paths to be a single glob string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.55"
+version = "0.1.56"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs/raw_configuration.rs
+++ b/src/packs/raw_configuration.rs
@@ -141,4 +141,14 @@ mod tests {
         assert!(raw_configuration.cache);
         assert_eq!(raw_configuration.cache_directory, "tmp/cache/packwerk");
     }
+
+    #[test]
+    fn test_deserialize_package_paths_as_string() {
+        let raw_configuration_string = String::from("package_paths: '**/*'");
+        let raw_configuration =
+            serde_yaml::from_str::<RawConfiguration>(&raw_configuration_string)
+                .expect("Could not deserialize package_paths as string");
+
+        assert_eq!(raw_configuration.package_paths, vec!["**/*"]);
+    }
 }

--- a/src/packs/raw_configuration.rs
+++ b/src/packs/raw_configuration.rs
@@ -145,7 +145,7 @@ where
         type Value = Vec<String>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("string or list of strings")
+            formatter.write_str("glob string or list of glob strings")
         }
 
         fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>


### PR DESCRIPTION
- write failing test
- fix test
- improve error message
- bump version
