### PR TITLE
Have packs caches live in subfolder of tmp/cache/packwerk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.57"
+version = "0.1.58"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -26,8 +26,6 @@ use crate::packs::parsing::ruby::zeitwerk::get_zeitwerk_constant_resolver;
 pub(crate) use configuration::Configuration;
 pub(crate) use package_todo::PackageTodo;
 
-use self::caching::create_cache_dir_idempotently;
-
 use self::parsing::ParsedDefinition;
 use self::parsing::UnresolvedReference;
 
@@ -66,14 +64,11 @@ pub struct SourceLocation {
 }
 
 pub(crate) fn list_definitions(configuration: &Configuration, ambiguous: bool) {
-    let initialized_dir =
-        create_cache_dir_idempotently(&configuration.cache_directory);
-
     let constant_resolver = if configuration.experimental_parser {
         let processed_files: Vec<ProcessedFile> = process_files_with_cache(
             &configuration.absolute_root,
             &configuration.included_files,
-            configuration.get_cache(initialized_dir),
+            configuration.get_cache(),
             configuration,
         );
 

--- a/src/packs/caching/mod.rs
+++ b/src/packs/caching/mod.rs
@@ -7,8 +7,6 @@ pub enum CacheResult {
     Miss(EmptyCacheEntry),
 }
 
-pub struct InitializedCacheDirectory;
-
 pub(crate) mod noop_cache;
 pub(crate) mod per_file_cache;
 
@@ -58,10 +56,7 @@ pub trait Cache {
     );
 }
 
-pub fn create_cache_dir_idempotently(
-    cache_dir: &Path,
-) -> InitializedCacheDirectory {
+pub fn create_cache_dir_idempotently(cache_dir: &Path) {
     std::fs::create_dir_all(cache_dir)
         .expect("Failed to create cache directory");
-    InitializedCacheDirectory
 }

--- a/src/packs/caching/per_file_cache.rs
+++ b/src/packs/caching/per_file_cache.rs
@@ -123,31 +123,20 @@ mod tests {
     fn test_compatible_with_packwerk() {
         let contents: String = String::from(
             r#"{
-    "file_contents_digest": "8f9efdcf2caa22fb7b1b4a8274e68d11",
-    "processed_file": {
-        "absolute_path": "/tests/fixtures/simple_app/packs/foo/app/services/bar/foo.rb",
-        "unresolved_references": [
-            {
-                "name": "Bar",
-                "namespace_path": [
-                    "Foo",
-                    "Bar"
-                ],
-                location: {
-                    "start_row": 8,
-                    "start_col": 22,
-                    "end_row": 8,
-                    "end_col": 25
-                }
-            }
-        ],
-        "definitions": []
-    }
+  "file_contents_digest":"8f9efdcf2caa22fb7b1b4a8274e68d11",
+  "processed_file": {
+    "absolute_path":"/tests/fixtures/simple_app/packs/foo/app/services/bar/foo.rb",
+    "unresolved_references":[
+      {
+        "name":"Bar",
+        "namespace_path":["Foo","Bar"],
+        "location":{"start_row":8,"start_col":22,"end_row":8,"end_col":25}
+      }],
+    "definitions":[]
+  }
 }"#,
         );
 
-        let actual_serialized =
-            serde_json::from_str::<CacheEntry>(&contents).unwrap();
         let expected_serialized = CacheEntry {
             file_contents_digest: "8f9efdcf2caa22fb7b1b4a8274e68d11".to_owned(),
             processed_file: ProcessedFile {
@@ -165,6 +154,9 @@ mod tests {
                 definitions: vec![],
             }
         };
+
+        let actual_serialized =
+            serde_json::from_str::<CacheEntry>(&contents).unwrap();
 
         assert_eq!(expected_serialized, actual_serialized);
 

--- a/src/packs/caching/per_file_cache.rs
+++ b/src/packs/caching/per_file_cache.rs
@@ -1,8 +1,4 @@
-use crate::packs::parsing::ParsedDefinition;
-use crate::packs::parsing::Range;
-use crate::packs::parsing::UnresolvedReference;
 use crate::packs::ProcessedFile;
-use crate::packs::SourceLocation;
 use serde::{Deserialize, Serialize};
 
 use std::fs::File;
@@ -30,7 +26,7 @@ impl Cache for PerFileCache {
             if !file_digests_match {
                 CacheResult::Miss(empty_cache_entry)
             } else {
-                let processed_file = cache_entry.processed_file(path);
+                let processed_file = cache_entry.processed_file;
                 CacheResult::Processed(processed_file)
             }
         } else {
@@ -45,30 +41,12 @@ impl Cache for PerFileCache {
     ) {
         let file_contents_digest =
             empty_cache_entry.file_contents_digest.to_owned();
-        let unresolved_references: Vec<ReferenceEntry> = processed_file
-            .unresolved_references
-            .iter()
-            .map(|r| -> ReferenceEntry {
-                ReferenceEntry {
-                    constant_name: r.name.to_owned(),
-                    namespace_path: r.namespace_path.to_owned(),
-                    relative_path: empty_cache_entry
-                        .relative_path_string()
-                        .to_owned(),
-                    source_location: SourceLocation {
-                        line: r.location.start_row,
-                        column: r.location.start_col,
-                    },
-                }
-            })
-            .collect();
-
-        let definitions = processed_file.definitions.clone();
 
         let cache_entry = &CacheEntry {
             file_contents_digest,
-            unresolved_references,
-            definitions,
+            // Ideally we could pass by reference here, but in practice this cost should be paid on few files
+            // that have changed and need to be reprocessed.
+            processed_file: processed_file.clone(),
         };
 
         let cache_data = serde_json::to_string(&cache_entry)
@@ -100,51 +78,7 @@ fn cache_entry_from_empty(empty: &EmptyCacheEntry) -> Option<CacheEntry> {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CacheEntry {
     pub file_contents_digest: String,
-    pub unresolved_references: Vec<ReferenceEntry>,
-    #[serde(default)]
-    pub definitions: Vec<ParsedDefinition>,
-}
-
-impl CacheEntry {
-    pub fn processed_file(self, absolute_path: &Path) -> ProcessedFile {
-        let unresolved_references = self
-            .unresolved_references
-            .iter()
-            .map(|reference| reference.to_unresolved_reference())
-            .collect();
-
-        ProcessedFile {
-            unresolved_references,
-            absolute_path: absolute_path.to_owned(),
-            definitions: self.definitions,
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize, Eq)]
-pub struct ReferenceEntry {
-    constant_name: String,
-    namespace_path: Vec<String>,
-    relative_path: String,
-    source_location: SourceLocation,
-}
-
-impl ReferenceEntry {
-    fn to_unresolved_reference(&self) -> UnresolvedReference {
-        UnresolvedReference {
-            name: self.constant_name.to_owned(),
-            namespace_path: self.namespace_path.to_owned(),
-            location: Range {
-                start_row: self.source_location.line,
-                start_col: self.source_location.column,
-                // The end row and end col can be improved here but we are limited
-                // because the cache does not store this data.
-                // Instead, we might just return a (resolved) Reference
-                end_row: self.source_location.line,
-                end_col: self.source_location.column + self.constant_name.len(),
-            },
-        }
-    }
+    pub processed_file: ProcessedFile,
 }
 
 pub fn read_json_file(
@@ -158,7 +92,11 @@ pub fn read_json_file(
 
 #[cfg(test)]
 mod tests {
-    use crate::packs::{self, configuration, file_utils::file_content_digest};
+    use crate::packs::{
+        self, configuration,
+        file_utils::file_content_digest,
+        parsing::{Range, UnresolvedReference},
+    };
 
     use super::*;
 
@@ -186,64 +124,25 @@ mod tests {
         let contents: String = String::from(
             r#"{
     "file_contents_digest": "8f9efdcf2caa22fb7b1b4a8274e68d11",
-    "unresolved_references": [
-        {
-            "constant_name": "Bar",
-            "namespace_path": [
-                "Foo",
-                "Bar"
-            ],
-            "relative_path": "packs/foo/app/services/bar/foo.rb",
-            "source_location": {
-                "line": 8,
-                "column": 22
+    "processed_file": {
+        "absolute_path": "/tests/fixtures/simple_app/packs/foo/app/services/bar/foo.rb",
+        "unresolved_references": [
+            {
+                "name": "Bar",
+                "namespace_path": [
+                    "Foo",
+                    "Bar"
+                ],
+                location: {
+                    "start_row": 8,
+                    "start_col": 22,
+                    "end_row": 8,
+                    "end_col": 25
+                }
             }
-        }
-    ]
-}"#,
-        );
-
-        let actual_serialized =
-            serde_json::from_str::<CacheEntry>(&contents).unwrap();
-        let expected_serialized = CacheEntry {
-            file_contents_digest: "8f9efdcf2caa22fb7b1b4a8274e68d11".to_owned(),
-            unresolved_references: vec![ReferenceEntry {
-                constant_name: "Bar".to_owned(),
-                namespace_path: vec!["Foo".to_owned(), "Bar".to_owned()],
-                relative_path: "packs/foo/app/services/bar/foo.rb".to_owned(),
-                source_location: SourceLocation {
-                    line: 8,
-                    column: 22,
-                },
-            }],
-            definitions: vec![],
-        };
-
-        assert_eq!(expected_serialized, actual_serialized);
-
-        teardown();
+        ],
+        "definitions": []
     }
-
-    #[test]
-    fn test_compatible_with_alternate_parser() {
-        let contents: String = String::from(
-            r#"{
-    "file_contents_digest": "8f9efdcf2caa22fb7b1b4a8274e68d11",
-    "unresolved_references": [
-        {
-            "constant_name": "Bar",
-            "namespace_path": [
-                "Foo",
-                "Bar"
-            ],
-            "relative_path": "packs/foo/app/services/bar/foo.rb",
-            "source_location": {
-                "line": 8,
-                "column": 22
-            }
-        }
-    ],
-    "definitions": []
 }"#,
         );
 
@@ -251,16 +150,20 @@ mod tests {
             serde_json::from_str::<CacheEntry>(&contents).unwrap();
         let expected_serialized = CacheEntry {
             file_contents_digest: "8f9efdcf2caa22fb7b1b4a8274e68d11".to_owned(),
-            unresolved_references: vec![ReferenceEntry {
-                constant_name: "Bar".to_owned(),
-                namespace_path: vec!["Foo".to_owned(), "Bar".to_owned()],
-                relative_path: "packs/foo/app/services/bar/foo.rb".to_owned(),
-                source_location: SourceLocation {
-                    line: 8,
-                    column: 22,
-                },
-            }],
-            definitions: vec![],
+            processed_file: ProcessedFile {
+                absolute_path: PathBuf::from("/tests/fixtures/simple_app/packs/foo/app/services/bar/foo.rb"),
+                unresolved_references: vec![UnresolvedReference {
+                    name: "Bar".to_owned(),
+                    namespace_path: vec!["Foo".to_owned(), "Bar".to_owned()],
+                    location: Range {
+                        start_row: 8,
+                        start_col: 22,
+                        end_row: 8,
+                        end_col: 25,
+                    }
+                }],
+                definitions: vec![],
+            }
         };
 
         assert_eq!(expected_serialized, actual_serialized);

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -1,4 +1,3 @@
-use crate::packs::caching::create_cache_dir_idempotently;
 use crate::packs::package_todo;
 use crate::packs::parsing::process_files_with_cache;
 use crate::packs::parsing::ruby::experimental::get_experimental_constant_resolver;
@@ -286,10 +285,7 @@ fn get_all_references(
     configuration: &Configuration,
     absolute_paths: &HashSet<PathBuf>,
 ) -> Vec<Reference> {
-    let initialized_dir =
-        create_cache_dir_idempotently(&configuration.cache_directory);
-
-    let cache = configuration.get_cache(initialized_dir);
+    let cache = configuration.get_cache();
 
     debug!("Getting unresolved references (using cache if possible)");
 

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -56,15 +56,15 @@ impl Configuration {
     }
 
     pub(crate) fn get_cache(&self) -> Box<dyn Cache + Send + Sync> {
-        let cache_dir = if self.experimental_parser {
-            self.cache_directory.join("experimental")
-        } else {
-            self.cache_directory.join("zeitwerk")
-        };
-
-        create_cache_dir_idempotently(&cache_dir);
-
         if self.cache_enabled {
+            let cache_dir = if self.experimental_parser {
+                self.cache_directory.join("experimental")
+            } else {
+                self.cache_directory.join("zeitwerk")
+            };
+
+            create_cache_dir_idempotently(&cache_dir);
+
             Box::new(PerFileCache { cache_dir })
         } else {
             Box::new(NoopCache {})

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -1,6 +1,6 @@
+use super::caching::create_cache_dir_idempotently;
 use super::caching::noop_cache::NoopCache;
 use super::caching::per_file_cache::PerFileCache;
-use super::caching::InitializedCacheDirectory;
 use super::checker::architecture::Layers;
 use super::file_utils::user_inputted_paths_to_absolute_filepaths;
 use super::raw_configuration::RawConfiguration;
@@ -55,16 +55,17 @@ impl Configuration {
         }
     }
 
-    pub(crate) fn get_cache(
-        &self,
-        // This takes an unused "InitializedCacheDirectory" argument, which is a sentinel
-        // value returned by
-        _initialized_dir: InitializedCacheDirectory,
-    ) -> Box<dyn Cache + Send + Sync> {
+    pub(crate) fn get_cache(&self) -> Box<dyn Cache + Send + Sync> {
+        let cache_dir = if self.experimental_parser {
+            self.cache_directory.join("experimental")
+        } else {
+            self.cache_directory.join("zeitwerk")
+        };
+
+        create_cache_dir_idempotently(&cache_dir);
+
         if self.cache_enabled {
-            Box::new(PerFileCache {
-                cache_dir: self.cache_directory.to_owned(),
-            })
+            Box::new(PerFileCache { cache_dir })
         } else {
             Box::new(NoopCache {})
         }

--- a/tests/delete_cache_test.rs
+++ b/tests/delete_cache_test.rs
@@ -27,7 +27,7 @@ fn test_delete_cache() -> Result<(), Box<dyn Error>> {
     // Write some dummy file to `tmp/cache/packwerk` to simulate a cache.
     let cache_dir =
         PathBuf::from("tests/fixtures/simple_app/tmp/cache/packwerk");
-    // Write cache_dir dir
+
     fs::create_dir_all(&cache_dir)?;
     let dummy_file = cache_dir.join("dummy_file");
     fs::write(dummy_file, "dummy file")?;


### PR DESCRIPTION
The idea here is the following:
- Originally, `packs` was attempting to provide a cache for the ruby `packwerk`, so we wanted to put the cache in the same location.
- Now, I wouldn't recommend using packs this way, and I don't think anyone is.
- The original implementation did a bunch of funny things to try to make the cache compatible with `packwerk`. We can remove this complexity by moving it into a separate folder.
- The experimental parser was *also* using the same folder. This made it really confusing to switch between the exerimental and non-experimental parsers, since they used the same cache locations but actually had incompatible cache data, even though the type shapes were compatible. This was really confusing and led to a sub-par experience.

# Commits 
- Caches should be in own folder
- only create cache dir if cache is enabled
- Simplify caching now that its in a different place
- fix tests
- bump version
