### PR TITLE
Implement `packs --experimental-parser expose-monkey-patches`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.63"
+version = "0.1.64"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Commands:
   update                          Update package_todo.yml files with the current violations
   validate                        Look for validation errors in the codebase
   check-unnecessary-dependencies  Check for dependencies that when removed produce no violations.
+  expose-monkey-patches           Expose monkey patches of the Ruby stdlib, gems your app uses, and your application itself
   delete-cache                    `rm -rf` on your cache directory, default `tmp/cache/packwerk`
   list-packs                      List packs based on configuration in packwerk.yml (for debugging purposes)
   list-included-files             List analyzed files based on configuration in packwerk.yml (for debugging purposes)

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -7,6 +7,7 @@ pub(crate) mod caching;
 pub(crate) mod checker;
 pub(crate) mod configuration;
 pub(crate) mod constant_resolver;
+pub(crate) mod monkey_patch_detection;
 pub(crate) mod pack;
 pub(crate) mod parsing;
 pub(crate) mod raw_configuration;
@@ -111,6 +112,21 @@ pub(crate) fn list_definitions(configuration: &Configuration, ambiguous: bool) {
             println!("{:?} is defined at {:?}", name, relative_path);
         }
     }
+}
+
+fn expose_monkey_patches(
+    configuration: &Configuration,
+    rubydir: &PathBuf,
+    gemdir: &PathBuf,
+) {
+    println!(
+        "{}",
+        monkey_patch_detection::expose_monkey_patches(
+            configuration,
+            rubydir,
+            gemdir,
+        )
+    )
 }
 
 #[cfg(test)]

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -62,6 +62,11 @@ enum Command {
     CheckUnnecessaryDependencies,
 
     #[clap(
+        about = "Expose monkey patches of the Ruby stdlib, gems your app uses, and your application itself"
+    )]
+    ExposeMonkeyPatches(ExposeMonkeyPatchesArgs),
+
+    #[clap(
         about = "`rm -rf` on your cache directory, default `tmp/cache/packwerk`"
     )]
     DeleteCache,
@@ -87,6 +92,19 @@ struct ListDefinitionsArgs {
     /// Show constants with multiple definitions only
     #[arg(short, long)]
     ambiguous: bool,
+}
+
+#[derive(Debug, Args)]
+struct ExposeMonkeyPatchesArgs {
+    /// An absolute path to the directory containing Ruby source code (for extracting definitions from Ruby stdlib)
+    /// Example: /Users/alex.evanczuk/.rbenv/versions/3.2.2/lib/ruby/3.2.0/
+    #[arg(short, long)]
+    rubydir: PathBuf,
+
+    /// An absolute path to the directory containing your gems (for extracting definitions from gem source code)
+    /// Example: /Users/alex.evanczuk/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/
+    #[arg(short, long)]
+    gemdir: PathBuf,
 }
 
 impl Args {
@@ -156,6 +174,14 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
         Command::ListDefinitions(args) => {
             let ambiguous = args.ambiguous;
             packs::list_definitions(&configuration, ambiguous);
+            Ok(())
+        }
+        Command::ExposeMonkeyPatches(args) => {
+            packs::expose_monkey_patches(
+                &configuration,
+                &args.rubydir,
+                &args.gemdir,
+            );
             Ok(())
         }
     }

--- a/src/packs/file_utils.rs
+++ b/src/packs/file_utils.rs
@@ -64,6 +64,22 @@ pub fn process_glob_pattern(pattern: &str, paths: &mut Vec<PathBuf>) {
     }
 }
 
+pub fn glob_ruby_files_in_dirs(dirs: Vec<&PathBuf>) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for dir in dirs {
+        let glob = dir.join("**/*.rb");
+        let pattern = glob.to_str().unwrap();
+        for path in glob::glob(pattern)
+            .expect("Failed to read glob pattern")
+            .flatten()
+        {
+            paths.push(path);
+        }
+    }
+
+    paths
+}
+
 pub fn user_inputted_paths_to_absolute_filepaths(
     absolute_root: &Path,
     input_paths: Vec<String>,

--- a/src/packs/file_utils.rs
+++ b/src/packs/file_utils.rs
@@ -146,7 +146,11 @@ pub fn file_read_contents(
         })
     } else {
         fs::read_to_string(path).unwrap_or_else(|_| {
-            panic!("Failed to read contents of {}", path.to_string_lossy())
+            println!(
+                "Failed to read contents of {} – skipping this file",
+                path.to_string_lossy()
+            );
+            "".to_string()
         })
     }
 }

--- a/src/packs/monkey_patch_detection.rs
+++ b/src/packs/monkey_patch_detection.rs
@@ -1,0 +1,234 @@
+use std::{cmp::Ordering, collections::HashMap, path::PathBuf};
+
+use tracing::debug;
+
+use crate::packs::{
+    constant_resolver::ConstantDefinition, file_utils::glob_ruby_files_in_dirs,
+    get_experimental_constant_resolver, process_files_with_cache,
+    ProcessedFile,
+};
+
+use super::Configuration;
+
+pub fn expose_monkey_patches(
+    configuration: &Configuration,
+    rubydir: &PathBuf,
+    gemdir: &PathBuf,
+) -> String {
+    let mut lines_to_print: Vec<String> = vec![];
+    if !configuration.experimental_parser {
+        panic!("This command is only supported with the experimental parser! `packs help` for more info.")
+    }
+
+    debug!("Globbing out rubydir and gemdir");
+
+    let other_files_to_parse = glob_ruby_files_in_dirs(vec![rubydir, gemdir]);
+    let mut included_files = configuration.included_files.clone();
+
+    included_files.extend(other_files_to_parse);
+
+    let processed_files: Vec<ProcessedFile> = process_files_with_cache(
+        &included_files,
+        configuration.get_cache(),
+        configuration,
+    );
+
+    let constant_resolver = get_experimental_constant_resolver(
+        &configuration.absolute_root,
+        &processed_files,
+        &configuration.ignored_definitions,
+    );
+
+    let constant_definition_map = constant_resolver
+        .fully_qualified_constant_name_to_constant_definition_map();
+
+    let mut ruby_monkey_patches: Vec<&ConstantDefinition> = vec![];
+    let mut gem_monkey_patches: Vec<&ConstantDefinition> = vec![];
+    let mut app_monkey_patches: Vec<&ConstantDefinition> = vec![];
+    let mut definitions_by_gem: HashMap<String, String> = HashMap::new();
+
+    constant_definition_map
+        .iter()
+        .for_each(|(_name, definitions)| {
+            let mut stdlib_defs: Vec<&ConstantDefinition> = vec![];
+            let mut gem_defs: Vec<&ConstantDefinition> = vec![];
+            let mut app_defs: Vec<&ConstantDefinition> = vec![];
+            definitions.iter().for_each(|d| {
+                let path = &d.absolute_path_of_definition;
+                if path.starts_with(rubydir) {
+                    stdlib_defs.push(d)
+                } else if path.starts_with(gemdir) {
+                    gem_defs.push(d)
+                } else {
+                    app_defs.push(d)
+                }
+            });
+
+            let stdlib_definitions_count = stdlib_defs.len();
+            let gem_definitions_count = gem_defs.len();
+
+            if gem_definitions_count > 0 {
+                for def in gem_defs {
+                    let relative_path = def
+                        .absolute_path_of_definition
+                        .strip_prefix(gemdir)
+                        .unwrap();
+                    let gem_name = relative_path
+                        .components()
+                        .next()
+                        .unwrap()
+                        .as_os_str()
+                        .to_str()
+                        .unwrap();
+
+                    definitions_by_gem.insert(
+                        def.fully_qualified_name.clone(),
+                        gem_name.to_owned(),
+                    );
+                }
+            }
+
+            let app_definitions_count = app_defs.len();
+            match (
+                stdlib_definitions_count,
+                gem_definitions_count,
+                app_definitions_count,
+            ) {
+                (1.., 1.., 0) => {
+                    // skip: gems monkey patching ruby
+                }
+                (1.., 0, 1..) => ruby_monkey_patches.extend(app_defs),
+                // This one is also gems monkey patching ruby, but we skip that info for now
+                (1.., 1.., 1..) => ruby_monkey_patches.extend(app_defs),
+                (0.., 1.., 1..) => gem_monkey_patches.extend(app_defs),
+                (0.., 0.., 2..) => app_monkey_patches.extend(app_defs),
+                (_, _, _) => {
+                    // skip
+                }
+            }
+        });
+
+    let constant_definition_sorting_function =
+        |a: &&ConstantDefinition, b: &&ConstantDefinition| {
+            // Compare by fully_qualified_name first
+            match a.fully_qualified_name.cmp(&b.fully_qualified_name) {
+                // If fully_qualified_name is the same, compare by absolute_path_of_definition
+                Ordering::Equal => a
+                    .absolute_path_of_definition
+                    .cmp(&b.absolute_path_of_definition),
+                // Otherwise, sort by fully_qualified_name
+                other => other,
+            }
+        };
+
+    lines_to_print.push("The following is a list of constants that are redefined by your app.\n".to_owned());
+    lines_to_print.push("# Ruby Standard Library".to_owned());
+    lines_to_print.push(format!("These monkey patches redefine behavior in the Ruby standard library (as determined by parsing the contents of `{}`):", rubydir.display()));
+
+    ruby_monkey_patches.sort_by(constant_definition_sorting_function);
+    gem_monkey_patches.sort_by(constant_definition_sorting_function);
+    app_monkey_patches.sort_by(constant_definition_sorting_function);
+
+    for definition in ruby_monkey_patches {
+        lines_to_print.push(get_redefinition_line_to_print(
+            &configuration.absolute_root,
+            definition,
+        ));
+    }
+
+    lines_to_print.push("\n# Gems".to_owned());
+    lines_to_print.push(format!("These monkey patches redefine behavior in gems your app depends on (as determined by parsing the contents of `{}`):", gemdir.display()));
+    for definition in gem_monkey_patches {
+        let relative_path = definition
+            .absolute_path_of_definition
+            .strip_prefix(&configuration.absolute_root)
+            .unwrap();
+
+        let gem_name = definitions_by_gem
+            .get(&definition.fully_qualified_name)
+            .unwrap();
+
+        lines_to_print.push(format!(
+            "{} (from gem `{}`) is redefined at {}",
+            definition.fully_qualified_name,
+            gem_name,
+            relative_path.display()
+        ))
+    }
+
+    lines_to_print.push("\n# Application".to_owned());
+    lines_to_print.push("These monkey patches redefine behavior in a pack within your app (as determined by parsing your app's packs):".to_owned());
+    for definition in app_monkey_patches {
+        lines_to_print.push(get_redefinition_line_to_print(
+            &configuration.absolute_root,
+            definition,
+        ));
+    }
+
+    lines_to_print.join("\n")
+}
+
+fn get_redefinition_line_to_print(
+    absolute_root: &PathBuf,
+    definition: &ConstantDefinition,
+) -> String {
+    let relative_path = definition
+        .absolute_path_of_definition
+        .strip_prefix(absolute_root)
+        .unwrap();
+    format!(
+        "{} is redefined at {}",
+        definition.fully_qualified_name,
+        relative_path.display(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use pretty_assertions::assert_eq;
+
+    use crate::packs::configuration;
+
+    use super::expose_monkey_patches;
+
+    #[test]
+    fn test_expose_monkey_patches() {
+        let expected_message = String::from("\
+The following is a list of constants that are redefined by your app.
+
+# Ruby Standard Library
+These monkey patches redefine behavior in the Ruby standard library (as determined by parsing the contents of `tests/fixtures/app_with_monkey_patches/rubydir_stub`):
+::Date is redefined at config/initializers/string_and_date_extensions.rb
+::String is redefined at config/initializers/string_and_date_extensions.rb
+
+# Gems
+These monkey patches redefine behavior in gems your app depends on (as determined by parsing the contents of `tests/fixtures/app_with_monkey_patches/gemdir_stub`):
+::Rails (from gem `rails`) is redefined at config/initializers/rails_monkeypatch.rb
+
+# Application
+These monkey patches redefine behavior in a pack within your app (as determined by parsing your app's packs):
+::Foo is redefined at packs/foo/app/models/foo.rb
+::Foo is redefined at packs/foo/app/services/foo.rb
+::SomeRootClass is redefined at app/models/some_root_class.rb
+::SomeRootClass is redefined at app/services/some_root_class.rb"
+      );
+
+        let mut configuration = configuration::get(&PathBuf::from(
+            "tests/fixtures/app_with_monkey_patches",
+        ));
+        configuration.experimental_parser = true;
+        let actual_message = expose_monkey_patches(
+            &configuration,
+            &PathBuf::from(
+                "tests/fixtures/app_with_monkey_patches/rubydir_stub",
+            ),
+            &PathBuf::from(
+                "tests/fixtures/app_with_monkey_patches/gemdir_stub",
+            ),
+        );
+
+        assert_eq!(expected_message, actual_message);
+    }
+}

--- a/src/packs/parsing/ruby/experimental/constant_resolver.rs
+++ b/src/packs/parsing/ruby/experimental/constant_resolver.rs
@@ -65,16 +65,19 @@ impl ExperimentalConstantResolver {
             {
                 let relative_path = constant
                     .absolute_path_of_definition
-                    .strip_prefix(absolute_root)
-                    .unwrap();
+                    .strip_prefix(absolute_root);
 
-                if definition_location.contains(relative_path) {
-                    debug!(
-                        "Ignoring definition of {:?} from {:?}",
-                        constant.fully_qualified_name,
-                        constant.absolute_path_of_definition
-                    );
-                    continue;
+                // The constant could be defined outside of the root in certain contexts,
+                // such as when using `expose-monkey-patches
+                if let Ok(relative_path) = relative_path {
+                    if definition_location.contains(relative_path) {
+                        debug!(
+                            "Ignoring definition of {:?} from {:?}",
+                            constant.fully_qualified_name,
+                            constant.absolute_path_of_definition
+                        );
+                        continue;
+                    }
                 }
             }
 

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -109,8 +109,7 @@ impl<'a> Visitor for ReferenceCollector<'a> {
     }
 
     fn on_module(&mut self, node: &nodes::Module) {
-        let namespace = fetch_const_name(&node.name)
-            .expect("We expect no parse errors in class/module definitions");
+        let namespace = fetch_const_name(&node.name).unwrap_or("".to_owned());
         let definition_loc = fetch_node_location(&node.name).unwrap();
         let location = loc_to_range(definition_loc, &self.line_col_lookup);
 

--- a/src/packs/parsing/ruby/parse_utils.rs
+++ b/src/packs/parsing/ruby/parse_utils.rs
@@ -68,12 +68,7 @@ pub fn fetch_const_name(node: &nodes::Node) -> Result<String, ParseError> {
         Node::Lvar(_) => Err(ParseError::Metaprogramming),
         Node::Ivar(_) => Err(ParseError::Metaprogramming),
         Node::Self_(_) => Err(ParseError::Metaprogramming),
-        node => {
-            panic!(
-                "Cannot handle other node in get_constant_node_name: {:?}",
-                node
-            )
-        }
+        _node => Err(ParseError::Metaprogramming),
     }
 }
 

--- a/tests/expose_monkey_patches_test.rs
+++ b/tests/expose_monkey_patches_test.rs
@@ -1,0 +1,25 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::{error::Error, process::Command};
+mod common;
+
+#[test]
+fn test_expose_monkey_patches() -> Result<(), Box<dyn Error>> {
+    // For the full test, see src/packs/monkey_patch_detection.rs
+    // This just ensures the CLI is hooked up correctly to the internal API
+    let expected_message_portion = String::from(
+        "The following is a list of constants that are redefined by your app.",
+    );
+    Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg("tests/fixtures/app_with_monkey_patches")
+        .arg("--experimental-parser")
+        .arg("expose-monkey-patches")
+        .arg("--rubydir=tests/fixtures/app_with_monkey_patches/rubydir_stub")
+        .arg("--gemdir=tests/fixtures/app_with_monkey_patches/gemdir_stub")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(expected_message_portion));
+
+    Ok(())
+}

--- a/tests/fixtures/app_with_monkey_patches/app/models/some_root_class.rb
+++ b/tests/fixtures/app_with_monkey_patches/app/models/some_root_class.rb
@@ -1,0 +1,3 @@
+class SomeRootClass
+  def bar; end
+end

--- a/tests/fixtures/app_with_monkey_patches/app/services/some_root_class.rb
+++ b/tests/fixtures/app_with_monkey_patches/app/services/some_root_class.rb
@@ -1,4 +1,6 @@
-class SomeRootClass; end
+class SomeRootClass
+  def foo; end
+end
 
 String
 

--- a/tests/fixtures/app_with_monkey_patches/config/initializers/rails_monkeypatch.rb
+++ b/tests/fixtures/app_with_monkey_patches/config/initializers/rails_monkeypatch.rb
@@ -1,0 +1,4 @@
+module Rails
+  def monkeypatched_behavior
+  end
+end

--- a/tests/fixtures/app_with_monkey_patches/gemdir_stub/activesupport/date.rb
+++ b/tests/fixtures/app_with_monkey_patches/gemdir_stub/activesupport/date.rb
@@ -1,0 +1,3 @@
+class Date
+  def do_a_thing; end
+end

--- a/tests/fixtures/app_with_monkey_patches/gemdir_stub/activesupport/string.rb
+++ b/tests/fixtures/app_with_monkey_patches/gemdir_stub/activesupport/string.rb
@@ -1,0 +1,3 @@
+class String
+  def do_a_thing; end
+end

--- a/tests/fixtures/app_with_monkey_patches/gemdir_stub/rails/rails.rb
+++ b/tests/fixtures/app_with_monkey_patches/gemdir_stub/rails/rails.rb
@@ -1,0 +1,4 @@
+module Rails
+  def some_behavior
+  end
+end

--- a/tests/fixtures/app_with_monkey_patches/packwerk.yml
+++ b/tests/fixtures/app_with_monkey_patches/packwerk.yml
@@ -6,8 +6,8 @@
 # - "**/*.{rb,rake,erb}"
 
 # List of patterns for folder paths to exclude
-# exclude:
-# - "{bin,node_modules,script,tmp,vendor}/**/*"
+exclude:
+- "{rubydir_stub,gemdir_stub}/**/*"
 
 # Patterns to find package configuration files
 # package_paths: "**/"

--- a/tests/fixtures/app_with_monkey_patches/rubydir_stub/date.rb
+++ b/tests/fixtures/app_with_monkey_patches/rubydir_stub/date.rb
@@ -1,0 +1,3 @@
+class Date
+  def do_a_thing; end
+end

--- a/tests/fixtures/app_with_monkey_patches/rubydir_stub/string.rb
+++ b/tests/fixtures/app_with_monkey_patches/rubydir_stub/string.rb
@@ -1,0 +1,3 @@
+class String
+  def do_a_thing; end
+end


### PR DESCRIPTION
This implements an experimental feature to expose monkey patches, allowing a user to see where their application is monkey patching the ruby stdlib, gems they use, or itself.

With the experimental parser, I realized we could point it at various directories and compare definitions of the same constant to identify monkey patches.

Theoretically it can also be used to see gems they use that monkey patch the ruby stdlib or other gems.

I'm not sure if knowing this information is valuable to orgs, but I thought it was an interesting feature to explore!