### PR TITLE
Various tidying up

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod packs;
 
 #[cfg(test)]
-pub(crate) mod test_util {
+mod test_util {
     use configuration::Configuration;
     use packs::parsing::ruby::zeitwerk::get_zeitwerk_constant_resolver;
     use std::collections::{HashMap, HashSet};
@@ -13,7 +13,8 @@ pub(crate) mod test_util {
     use crate::packs::pack::Pack;
     use crate::packs::raw_configuration::RawConfiguration;
     use crate::packs::walk_directory::WalkDirectoryResult;
-    use crate::packs::{self, constant_resolver::ConstantResolver};
+    use crate::packs::{self};
+    use crate::packs::constant_resolver::ConstantResolver;
 
     pub const SIMPLE_APP: &str = "tests/fixtures/simple_app";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,11 @@ mod test_util {
     use packs::configuration;
 
     use crate::packs::configuration::from_raw;
+    use crate::packs::constant_resolver::ConstantResolver;
     use crate::packs::pack::Pack;
     use crate::packs::raw_configuration::RawConfiguration;
     use crate::packs::walk_directory::WalkDirectoryResult;
     use crate::packs::{self};
-    use crate::packs::constant_resolver::ConstantResolver;
 
     pub const SIMPLE_APP: &str = "tests/fixtures/simple_app";
 

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -15,6 +15,7 @@ pub(crate) mod package_todo;
 pub(crate) mod parsing;
 pub(crate) mod raw_configuration;
 pub(crate) mod raw_pack;
+pub(crate) mod reference_extractor;
 pub(crate) mod walk_directory;
 
 // Internal imports

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -1,4 +1,5 @@
-// Public APIs
+// Currently there are no supported library APIs for packs. The public API is the CLI.
+// This may change in the future! Please file an issue if you have a use case for a library API.
 pub mod cli;
 
 pub(crate) mod caching;

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -1,21 +1,22 @@
+pub(crate) mod caching;
+pub(crate) mod checker;
+pub mod cli;
 pub(crate) mod configuration;
+pub(crate) mod constant_resolver;
+pub(crate) mod file_utils;
+pub mod logger;
 pub(crate) mod pack;
+mod pack_set;
+pub mod package_todo;
+pub mod parsing;
 pub(crate) mod raw_configuration;
 mod raw_pack;
+pub(crate) mod walk_directory;
+
 use serde::Deserialize;
 use serde::Serialize;
 
 use std::path::PathBuf;
-pub(crate) mod caching;
-pub(crate) mod checker;
-pub mod cli;
-pub(crate) mod constant_resolver;
-pub(crate) mod file_utils;
-pub mod logger;
-mod pack_set;
-pub mod package_todo;
-pub mod parsing;
-pub(crate) mod walk_directory;
 
 // Re-exports: Eventually, these may be part of the public API for packs
 pub(crate) use crate::packs::checker::Violation;

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -2,6 +2,7 @@
 // This may change in the future! Please file an issue if you have a use case for a library API.
 pub mod cli;
 
+// Module declarations
 pub(crate) mod caching;
 pub(crate) mod checker;
 pub(crate) mod configuration;
@@ -16,6 +17,7 @@ pub(crate) mod raw_configuration;
 pub(crate) mod raw_pack;
 pub(crate) mod walk_directory;
 
+// Internal re-exports
 pub(crate) use self::checker::Violation;
 pub(crate) use self::pack_set::PackSet;
 pub(crate) use self::parsing::process_files_with_cache;

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -7,16 +7,17 @@ pub(crate) mod caching;
 pub(crate) mod checker;
 pub(crate) mod configuration;
 pub(crate) mod constant_resolver;
-pub(crate) mod file_utils;
-pub(crate) mod logger;
 pub(crate) mod pack;
-pub(crate) mod pack_set;
-pub(crate) mod package_todo;
 pub(crate) mod parsing;
 pub(crate) mod raw_configuration;
-pub(crate) mod raw_pack;
-pub(crate) mod reference_extractor;
 pub(crate) mod walk_directory;
+
+mod file_utils;
+mod logger;
+mod pack_set;
+mod package_todo;
+mod raw_pack;
+mod reference_extractor;
 
 // Internal imports
 pub(crate) use self::checker::Violation;

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -21,17 +21,15 @@ use serde::Serialize;
 
 use std::path::PathBuf;
 
-// Re-exports: Eventually, these may be part of the public API for packs
-pub(crate) use crate::packs::checker::Violation;
-pub(crate) use crate::packs::pack_set::PackSet;
-use crate::packs::parsing::process_files_with_cache;
-use crate::packs::parsing::ruby::experimental::get_experimental_constant_resolver;
-use crate::packs::parsing::ruby::zeitwerk::get_zeitwerk_constant_resolver;
+pub(crate) use self::checker::Violation;
+pub(crate) use self::pack_set::PackSet;
+pub(crate) use self::parsing::process_files_with_cache;
+pub(crate) use self::parsing::ruby::experimental::get_experimental_constant_resolver;
+pub(crate) use self::parsing::ruby::zeitwerk::get_zeitwerk_constant_resolver;
+pub(crate) use self::parsing::ParsedDefinition;
+pub(crate) use self::parsing::UnresolvedReference;
 pub(crate) use configuration::Configuration;
 pub(crate) use package_todo::PackageTodo;
-
-use self::parsing::ParsedDefinition;
-use self::parsing::UnresolvedReference;
 
 pub fn greet() {
     println!("👋 Hello! Welcome to packs 📦 🔥 🎉 🌈. This tool is under construction.")

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -16,11 +16,6 @@ pub(crate) mod raw_configuration;
 pub(crate) mod raw_pack;
 pub(crate) mod walk_directory;
 
-use serde::Deserialize;
-use serde::Serialize;
-
-use std::path::PathBuf;
-
 pub(crate) use self::checker::Violation;
 pub(crate) use self::pack_set::PackSet;
 pub(crate) use self::parsing::process_files_with_cache;
@@ -30,6 +25,10 @@ pub(crate) use self::parsing::ParsedDefinition;
 pub(crate) use self::parsing::UnresolvedReference;
 pub(crate) use configuration::Configuration;
 pub(crate) use package_todo::PackageTodo;
+
+use serde::Deserialize;
+use serde::Serialize;
+use std::path::PathBuf;
 
 pub fn greet() {
     println!("👋 Hello! Welcome to packs 📦 🔥 🎉 🌈. This tool is under construction.")

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -1,16 +1,18 @@
+// Public APIs
+pub mod cli;
+
 pub(crate) mod caching;
 pub(crate) mod checker;
-pub mod cli;
 pub(crate) mod configuration;
 pub(crate) mod constant_resolver;
 pub(crate) mod file_utils;
-pub mod logger;
+pub(crate) mod logger;
 pub(crate) mod pack;
-mod pack_set;
-pub mod package_todo;
-pub mod parsing;
+pub(crate) mod pack_set;
+pub(crate) mod package_todo;
+pub(crate) mod parsing;
 pub(crate) mod raw_configuration;
-mod raw_pack;
+pub(crate) mod raw_pack;
 pub(crate) mod walk_directory;
 
 use serde::Deserialize;

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -17,7 +17,7 @@ pub(crate) mod raw_configuration;
 pub(crate) mod raw_pack;
 pub(crate) mod walk_directory;
 
-// Internal re-exports
+// Internal imports
 pub(crate) use self::checker::Violation;
 pub(crate) use self::pack_set::PackSet;
 pub(crate) use self::parsing::process_files_with_cache;
@@ -28,6 +28,7 @@ pub(crate) use self::parsing::UnresolvedReference;
 pub(crate) use configuration::Configuration;
 pub(crate) use package_todo::PackageTodo;
 
+// External imports
 use serde::Deserialize;
 use serde::Serialize;
 use std::path::PathBuf;

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -8,12 +8,8 @@ pub(crate) mod visibility;
 // Internal imports
 use crate::packs::pack::Pack;
 use crate::packs::package_todo;
-use crate::packs::parsing::process_files_with_cache;
-use crate::packs::parsing::ruby::experimental::get_experimental_constant_resolver;
-use crate::packs::parsing::ruby::zeitwerk::get_zeitwerk_constant_resolver;
 use crate::packs::Configuration;
 use crate::packs::PackSet;
-use crate::packs::ProcessedFile;
 
 // External imports
 use rayon::prelude::IntoParallelIterator;
@@ -23,6 +19,8 @@ use reference::Reference;
 use std::collections::HashMap;
 use std::{collections::HashSet, path::PathBuf};
 use tracing::debug;
+
+use super::reference_extractor::get_all_references;
 
 #[derive(PartialEq, Eq, Hash, Debug)]
 pub struct ViolationIdentifier {
@@ -320,79 +318,6 @@ fn get_all_violations(
     debug!("Finished running checkers");
 
     violations
-}
-
-fn get_all_references(
-    configuration: &Configuration,
-    absolute_paths: &HashSet<PathBuf>,
-) -> Vec<Reference> {
-    let cache = configuration.get_cache();
-
-    debug!("Getting unresolved references (using cache if possible)");
-
-    let (constant_resolver, processed_files_to_check) = if configuration
-        .experimental_parser
-    {
-        // The experimental parser needs *all* processed files to get definitions
-        let all_processed_files: Vec<ProcessedFile> = process_files_with_cache(
-            &configuration.included_files,
-            cache,
-            configuration,
-        );
-
-        let constant_resolver = get_experimental_constant_resolver(
-            &configuration.absolute_root,
-            &all_processed_files,
-            &configuration.ignored_definitions,
-        );
-
-        let processed_files_to_check = all_processed_files
-            .into_iter()
-            .filter(|processed_file| {
-                absolute_paths.contains(&processed_file.absolute_path)
-            })
-            .collect();
-
-        (constant_resolver, processed_files_to_check)
-    } else {
-        let processed_files: Vec<ProcessedFile> =
-            process_files_with_cache(absolute_paths, cache, configuration);
-
-        // The zeitwerk constant resolver doesn't look at processed files to get definitions
-        let constant_resolver = get_zeitwerk_constant_resolver(
-            &configuration.pack_set,
-            &configuration.absolute_root,
-            &configuration.cache_directory,
-            !configuration.cache_enabled,
-        );
-
-        (constant_resolver, processed_files)
-    };
-
-    debug!("Turning unresolved references into fully qualified references");
-    let references: Vec<Reference> = processed_files_to_check
-        .par_iter()
-        .flat_map(|processed_file| {
-            let references: Vec<Reference> = processed_file
-                .unresolved_references
-                .iter()
-                .flat_map(|unresolved_ref| {
-                    Reference::from_unresolved_reference(
-                        configuration,
-                        constant_resolver.as_ref(),
-                        unresolved_ref,
-                        &processed_file.absolute_path,
-                    )
-                })
-                .collect::<Vec<Reference>>();
-
-            references
-        })
-        .collect();
-
-    debug!("Finished turning unresolved references into fully qualified references");
-
-    references
 }
 
 fn get_checkers(

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -1,9 +1,9 @@
 // Module declarations
 pub(crate) mod architecture;
-pub(crate) mod dependency;
-pub(crate) mod privacy;
+mod dependency;
+mod privacy;
 pub(crate) mod reference;
-pub(crate) mod visibility;
+mod visibility;
 
 // Internal imports
 use crate::packs::pack::Pack;

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -1,29 +1,28 @@
+// Module declarations
+pub(crate) mod architecture;
+pub(crate) mod dependency;
+pub(crate) mod privacy;
+pub(crate) mod reference;
+pub(crate) mod visibility;
+
+// Internal imports
+use crate::packs::pack::Pack;
 use crate::packs::package_todo;
 use crate::packs::parsing::process_files_with_cache;
 use crate::packs::parsing::ruby::experimental::get_experimental_constant_resolver;
 use crate::packs::parsing::ruby::zeitwerk::get_zeitwerk_constant_resolver;
-
 use crate::packs::Configuration;
+use crate::packs::PackSet;
 use crate::packs::ProcessedFile;
 
+// External imports
 use rayon::prelude::IntoParallelIterator;
 use rayon::prelude::IntoParallelRefIterator;
 use rayon::prelude::ParallelIterator;
-
+use reference::Reference;
 use std::collections::HashMap;
 use std::{collections::HashSet, path::PathBuf};
 use tracing::debug;
-
-pub mod architecture;
-pub mod dependency;
-pub mod privacy;
-pub mod visibility;
-
-pub(crate) mod reference;
-use reference::Reference;
-
-use super::pack::Pack;
-use super::PackSet;
 
 #[derive(PartialEq, Eq, Hash, Debug)]
 pub struct ViolationIdentifier {

--- a/src/packs/parsing/erb/mod.rs
+++ b/src/packs/parsing/erb/mod.rs
@@ -1,2 +1,2 @@
-pub mod experimental;
-pub mod packwerk;
+pub(crate) mod experimental;
+pub(crate) mod packwerk;

--- a/src/packs/parsing/mod.rs
+++ b/src/packs/parsing/mod.rs
@@ -6,7 +6,7 @@ use std::{
 pub(crate) mod ruby;
 pub(crate) use ruby::experimental::parser::process_from_path as process_from_ruby_path_experimental;
 pub(crate) use ruby::packwerk::parser::process_from_path as process_from_ruby_path;
-pub(crate) mod erb;
+mod erb;
 pub(crate) use erb::experimental::parser::process_from_path as process_from_erb_path_experimental;
 pub(crate) use erb::packwerk::parser::process_from_path as process_from_erb_path;
 

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -1,20 +1,17 @@
-use std::{
-    collections::{HashMap, HashSet},
-    path::{Path, PathBuf},
-};
+pub(crate) mod constant_resolver;
+pub(crate) mod parser;
 
-use rayon::prelude::{IntoParallelIterator, ParallelIterator};
-
+use self::constant_resolver::ExperimentalConstantResolver;
 use crate::packs::{
     constant_resolver::{ConstantDefinition, ConstantResolver},
     ProcessedFile,
 };
 
-use self::constant_resolver::ExperimentalConstantResolver;
-
-pub mod constant_resolver;
-
-pub(crate) mod parser;
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
 
 pub fn get_experimental_constant_resolver(
     absolute_root: &Path,

--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -1,4 +1,4 @@
-pub(crate) mod constant_resolver;
+mod constant_resolver;
 pub(crate) mod parser;
 
 use self::constant_resolver::ExperimentalConstantResolver;

--- a/src/packs/parsing/ruby/mod.rs
+++ b/src/packs/parsing/ruby/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) mod experimental;
-pub(crate) mod inflector_shim;
-pub(crate) mod namespace_calculator;
+mod inflector_shim;
+mod namespace_calculator;
 pub(crate) mod packwerk;
-pub(crate) mod parse_utils;
-pub(crate) mod rails_utils;
-pub(crate) mod ruby_utils;
+mod parse_utils;
+mod rails_utils;
+mod ruby_utils;
 pub(crate) mod zeitwerk;

--- a/src/packs/parsing/ruby/mod.rs
+++ b/src/packs/parsing/ruby/mod.rs
@@ -1,8 +1,8 @@
-pub mod experimental;
+pub(crate) mod experimental;
 pub(crate) mod inflector_shim;
-pub mod namespace_calculator;
-pub mod packwerk;
-pub mod parse_utils;
+pub(crate) mod namespace_calculator;
+pub(crate) mod packwerk;
+pub(crate) mod parse_utils;
 pub(crate) mod rails_utils;
-pub mod ruby_utils;
-pub mod zeitwerk;
+pub(crate) mod ruby_utils;
+pub(crate) mod zeitwerk;

--- a/src/packs/parsing/ruby/zeitwerk/mod.rs
+++ b/src/packs/parsing/ruby/zeitwerk/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod constant_resolver;
+mod constant_resolver;
 
 use std::{
     collections::{HashMap, HashSet},

--- a/src/packs/reference_extractor.rs
+++ b/src/packs/reference_extractor.rs
@@ -1,0 +1,84 @@
+use std::{collections::HashSet, path::PathBuf};
+
+use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use tracing::debug;
+
+use crate::packs::{
+    get_experimental_constant_resolver, get_zeitwerk_constant_resolver,
+    process_files_with_cache, ProcessedFile,
+};
+
+use super::{checker::reference::Reference, Configuration};
+
+pub(crate) fn get_all_references(
+    configuration: &Configuration,
+    absolute_paths: &HashSet<PathBuf>,
+) -> Vec<Reference> {
+    let cache = configuration.get_cache();
+
+    debug!("Getting unresolved references (using cache if possible)");
+
+    let (constant_resolver, processed_files_to_check) = if configuration
+        .experimental_parser
+    {
+        // The experimental parser needs *all* processed files to get definitions
+        let all_processed_files: Vec<ProcessedFile> = process_files_with_cache(
+            &configuration.included_files,
+            cache,
+            configuration,
+        );
+
+        let constant_resolver = get_experimental_constant_resolver(
+            &configuration.absolute_root,
+            &all_processed_files,
+            &configuration.ignored_definitions,
+        );
+
+        let processed_files_to_check = all_processed_files
+            .into_iter()
+            .filter(|processed_file| {
+                absolute_paths.contains(&processed_file.absolute_path)
+            })
+            .collect();
+
+        (constant_resolver, processed_files_to_check)
+    } else {
+        let processed_files: Vec<ProcessedFile> =
+            process_files_with_cache(absolute_paths, cache, configuration);
+
+        // The zeitwerk constant resolver doesn't look at processed files to get definitions
+        let constant_resolver = get_zeitwerk_constant_resolver(
+            &configuration.pack_set,
+            &configuration.absolute_root,
+            &configuration.cache_directory,
+            !configuration.cache_enabled,
+        );
+
+        (constant_resolver, processed_files)
+    };
+
+    debug!("Turning unresolved references into fully qualified references");
+    let references: Vec<Reference> = processed_files_to_check
+        .par_iter()
+        .flat_map(|processed_file| {
+            let references: Vec<Reference> = processed_file
+                .unresolved_references
+                .iter()
+                .flat_map(|unresolved_ref| {
+                    Reference::from_unresolved_reference(
+                        configuration,
+                        constant_resolver.as_ref(),
+                        unresolved_ref,
+                        &processed_file.absolute_path,
+                    )
+                })
+                .collect::<Vec<Reference>>();
+
+            references
+        })
+        .collect();
+
+    debug!("Finished turning unresolved references into fully qualified references");
+
+    references
+}


### PR DESCRIPTION
Updates visibility of modules and pulls out a "Reference extractor" module.
- add commands module
- reorganize imports
- make things private
- add comment
- reorganize other main imports
- reorganize library imports
- add ocmment
- reorganize other imports
- wip
- more module reorgs
- make things private
