### PR TITLE
Bump lib-ruby-parser to fix panic when parsing certain pattern matching syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tracing = "0.1.37" # logging
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] } # logging
 glob = "0.3.1" # globbing
 globset = "0.4.10" # globbing
-lib-ruby-parser = "4.0.4" # ruby parser
+lib-ruby-parser = "4.0.5" # ruby parser
 md5 = "0.7.0" # md5 hashing to take and compare md5 digests of file contents to ensure cache validity
 line-col = "0.2.1" # for creating source maps of violations
 ruby_inflector = '0.0.8' # for inflecting strings, e.g. turning `has_many :companies` into `Company`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.62"
+version = "0.1.63"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"


### PR DESCRIPTION
```
config = { a: { b: :c } }
config => a: {b:}
```

This syntax was unsupported.

See https://github.com/lib-ruby-parser/lib-ruby-parser/issues/85 for more info
