### PR TITLE
Add option to ignore recorded violations

### DIFF
--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -113,7 +113,7 @@ pub(crate) fn check_all(
 
     debug!("Filtering out recorded violations");
 
-    let unrecorded_violations: Vec<&Violation> =
+    let reportable_violations: Vec<&Violation> =
         if configuration.ignore_recorded_violations {
             debug!("Filtering recorded violations is disabled in config");
             found_violations.iter().collect()
@@ -176,12 +176,12 @@ pub(crate) fn check_all(
 
     let mut errors_present = false;
 
-    if !unrecorded_violations.is_empty() {
-        for violation in unrecorded_violations.iter() {
+    if !reportable_violations.is_empty() {
+        for violation in reportable_violations.iter() {
             println!("{}\n", violation.message);
         }
 
-        println!("{} violation(s) detected:", unrecorded_violations.len());
+        println!("{} violation(s) detected:", reportable_violations.len());
 
         errors_present = true;
     }

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -112,10 +112,17 @@ pub(crate) fn check_all(
     let recorded_violations = &configuration.pack_set.all_violations;
 
     debug!("Filtering out recorded violations");
-    let unrecorded_violations = found_violations
-        .iter()
-        .filter(|v| !recorded_violations.contains(&v.identifier))
-        .collect::<Vec<&Violation>>();
+
+    let unrecorded_violations: Vec<&Violation> =
+        if configuration.ignore_recorded_violations {
+            debug!("Filtering recorded violations is disabled in config");
+            found_violations.iter().collect()
+        } else {
+            found_violations
+                .iter()
+                .filter(|v| !recorded_violations.contains(&v.identifier))
+                .collect()
+        };
 
     debug!("Finished filtering out recorded violations");
 

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -43,10 +43,22 @@ enum Command {
     Greet,
 
     #[clap(about = "Look for violations in the codebase")]
-    Check { files: Vec<String> },
+    Check {
+        /// Ignore recorded violations when reporting violations
+        #[arg(long)]
+        ignore_recorded_violations: bool,
+
+        files: Vec<String>,
+    },
 
     #[clap(about = "Check file contents piped to stdin")]
-    CheckContents { file: String },
+    CheckContents {
+        /// Ignore recorded violations when reporting violations
+        #[arg(long)]
+        ignore_recorded_violations: bool,
+
+        file: String,
+    },
 
     #[clap(
         about = "Update package_todo.yml files with the current violations"
@@ -134,7 +146,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     if args.no_cache {
         debug!("Cache is disabled");
-        configuration.cache_enabled = false
+        configuration.cache_enabled = false;
     }
 
     match args.command {
@@ -153,8 +165,21 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
                 .for_each(|f| println!("{}", f.display()));
             Ok(())
         }
-        Command::Check { files } => checker::check_all(configuration, files),
-        Command::CheckContents { file } => {
+        Command::Check {
+            ignore_recorded_violations,
+            files,
+        } => {
+            configuration.ignore_recorded_violations =
+                ignore_recorded_violations;
+            checker::check_all(configuration, files)
+        }
+        Command::CheckContents {
+            ignore_recorded_violations,
+            file,
+        } => {
+            configuration.ignore_recorded_violations =
+                ignore_recorded_violations;
+
             let absolute_path = get_absolute_path(file.clone(), &configuration);
             configuration.stdin_file_path = Some(absolute_path);
             checker::check_all(configuration, vec![file])

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -36,6 +36,7 @@ pub struct Configuration {
     // grows, we can refactor this.
     pub print_files: bool,
     pub packs_first_mode: bool,
+    pub ignore_recorded_violations: bool,
 }
 
 impl Configuration {
@@ -120,6 +121,7 @@ pub(crate) fn from_raw(
 
     let stdin_file_path: Option<PathBuf> = None;
     let print_files = false;
+    let ignore_recorded_violations = false;
 
     Configuration {
         included_files,
@@ -134,6 +136,7 @@ pub(crate) fn from_raw(
         stdin_file_path,
         print_files,
         packs_first_mode,
+        ignore_recorded_violations,
     }
 }
 

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -76,6 +76,26 @@ fn test_check_with_package_todo_file() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn test_check_with_package_todo_file_ignoring_recorded_violations(
+) -> Result<(), Box<dyn Error>> {
+    Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg("tests/fixtures/contains_package_todo")
+        .arg("--debug")
+        .arg("check")
+        .arg("--ignore-recorded-violations")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("2 violation(s) detected:"))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
+        .stdout(predicate::str::contains("packs/foo/app/services/other_foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
+
+    common::teardown();
+
+    Ok(())
+}
+
+#[test]
 fn test_check_with_experimental_parser() -> Result<(), Box<dyn Error>> {
     Command::cargo_bin("packs")
         .unwrap()
@@ -154,15 +174,14 @@ fn test_check_with_strict_mode() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_check_contents() -> Result<(), Box<dyn Error>> {
+    let project_root = "tests/fixtures/simple_app";
     let relative_path = "packs/foo/app/services/foo.rb";
-    let foo_rb_contents = fs::read_to_string(format!(
-        "tests/fixtures/simple_app/{}",
-        relative_path
-    ))?;
+    let foo_rb_contents =
+        fs::read_to_string(format!("{}/{}", project_root, relative_path))?;
 
     Command::cargo_bin("packs")?
         .arg("--project-root")
-        .arg("tests/fixtures/simple_app")
+        .arg(project_root)
         .arg("--debug")
         .arg("check-contents")
         .arg(relative_path)
@@ -172,6 +191,31 @@ fn test_check_contents() -> Result<(), Box<dyn Error>> {
         .stdout(predicate::str::contains("2 violation(s) detected:"))
         .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:6:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
         .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:6:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
+
+    common::teardown();
+    Ok(())
+}
+
+#[test]
+fn test_check_contents_ignoring_recorded_violations(
+) -> Result<(), Box<dyn Error>> {
+    let project_root = "tests/fixtures/contains_package_todo";
+    let relative_path = "packs/foo/app/services/foo.rb";
+    let foo_rb_contents =
+        fs::read_to_string(format!("{}/{}", project_root, relative_path))?;
+
+    Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg(project_root)
+        .arg("--debug")
+        .arg("check-contents")
+        .arg("--ignore-recorded-violations")
+        .arg(relative_path)
+        .write_stdin(format!("\n\n\n{}", foo_rb_contents))
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("1 violation(s) detected:"))
+        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:6:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
 
     common::teardown();
     Ok(())


### PR DESCRIPTION
This adds a command-line option `--ignore-recorded-violations` to `check` and `check-contents` commands that skips filtering out recorded violations. This is especially useful in editor integrations to see all the violations, even those recorded in `package_todo.yml`.