### PR TITLE
Bump version to 0.1.66

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.65"
+version = "0.1.66"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"


### PR DESCRIPTION
This is to build a new release with the newest additions to `main`. 😄 