### PR TITLE
Improve the output of expose monkey patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.66"
+version = "0.1.67"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs/monkey_patch_detection.rs
+++ b/src/packs/monkey_patch_detection.rs
@@ -200,19 +200,32 @@ The following is a list of constants that are redefined by your app.
 
 # Ruby Standard Library
 These monkey patches redefine behavior in the Ruby standard library (as determined by parsing the contents of `tests/fixtures/app_with_monkey_patches/rubydir_stub`):
-::Date is redefined at config/initializers/string_and_date_extensions.rb
-::String is redefined at config/initializers/string_and_date_extensions.rb
+
+<details>
+<summary>Click here</summary>
+
+- `::Date` is redefined at [config/initializers/string_and_date_extensions.rb](config/initializers/string_and_date_extensions.rb)
+- `::String` is redefined at [config/initializers/string_and_date_extensions.rb](config/initializers/string_and_date_extensions.rb)
+</details>
 
 # Gems
 These monkey patches redefine behavior in gems your app depends on (as determined by parsing the contents of `tests/fixtures/app_with_monkey_patches/gemdir_stub`):
-::Rails (from gem `rails`) is redefined at config/initializers/rails_monkeypatch.rb
+<details>
+<summary>Click here</summary>
+
+- `::Rails` (from gem `rails`) is redefined at [config/initializers/rails_monkeypatch.rb](config/initializers/rails_monkeypatch.rb)
+</details>
 
 # Application
 These monkey patches redefine behavior in a pack within your app (as determined by parsing your app's packs):
-::Foo is redefined at packs/foo/app/models/foo.rb
-::Foo is redefined at packs/foo/app/services/foo.rb
-::SomeRootClass is redefined at app/models/some_root_class.rb
-::SomeRootClass is redefined at app/services/some_root_class.rb"
+<details>
+<summary>Click here</summary>
+
+- `::Foo` is redefined at [packs/foo/app/models/foo.rb](packs/foo/app/models/foo.rb)
+- `::Foo` is redefined at [packs/foo/app/services/foo.rb](packs/foo/app/services/foo.rb)
+- `::SomeRootClass` is redefined at [app/models/some_root_class.rb](app/models/some_root_class.rb)
+- `::SomeRootClass` is redefined at [app/services/some_root_class.rb](app/services/some_root_class.rb)
+</details>"
       );
 
         let mut configuration = configuration::get(&PathBuf::from(

--- a/src/packs/monkey_patch_detection.rs
+++ b/src/packs/monkey_patch_detection.rs
@@ -124,6 +124,11 @@ pub fn expose_monkey_patches(
     lines_to_print.push("The following is a list of constants that are redefined by your app.\n".to_owned());
     lines_to_print.push("# Ruby Standard Library".to_owned());
     lines_to_print.push(format!("These monkey patches redefine behavior in the Ruby standard library (as determined by parsing the contents of `{}`):", rubydir.display()));
+    lines_to_print.push("".to_owned());
+
+    lines_to_print.push("<details>".to_owned());
+    lines_to_print.push("<summary>Click here</summary>".to_owned());
+    lines_to_print.push("".to_owned());
 
     ruby_monkey_patches.sort_by(constant_definition_sorting_function);
     gem_monkey_patches.sort_by(constant_definition_sorting_function);
@@ -136,8 +141,15 @@ pub fn expose_monkey_patches(
         ));
     }
 
+    lines_to_print.push("</details>".to_owned());
+
     lines_to_print.push("\n# Gems".to_owned());
     lines_to_print.push(format!("These monkey patches redefine behavior in gems your app depends on (as determined by parsing the contents of `{}`):", gemdir.display()));
+
+    lines_to_print.push("<details>".to_owned());
+    lines_to_print.push("<summary>Click here</summary>".to_owned());
+    lines_to_print.push("".to_owned());
+
     for definition in gem_monkey_patches {
         let relative_path = definition
             .absolute_path_of_definition
@@ -149,21 +161,31 @@ pub fn expose_monkey_patches(
             .unwrap();
 
         lines_to_print.push(format!(
-            "{} (from gem `{}`) is redefined at {}",
+            "- `{}` (from gem `{}`) is redefined at [{}]({})",
             definition.fully_qualified_name,
             gem_name,
+            relative_path.display(),
             relative_path.display()
         ))
     }
 
+    lines_to_print.push("</details>".to_owned());
+
     lines_to_print.push("\n# Application".to_owned());
     lines_to_print.push("These monkey patches redefine behavior in a pack within your app (as determined by parsing your app's packs):".to_owned());
+
+    lines_to_print.push("<details>".to_owned());
+    lines_to_print.push("<summary>Click here</summary>".to_owned());
+    lines_to_print.push("".to_owned());
+
     for definition in app_monkey_patches {
         lines_to_print.push(get_redefinition_line_to_print(
             &configuration.absolute_root,
             definition,
         ));
     }
+
+    lines_to_print.push("</details>".to_owned());
 
     lines_to_print.join("\n")
 }
@@ -177,8 +199,9 @@ fn get_redefinition_line_to_print(
         .strip_prefix(absolute_root)
         .unwrap();
     format!(
-        "{} is redefined at {}",
+        "- `{}` is redefined at [{}]({})",
         definition.fully_qualified_name,
+        relative_path.display(),
         relative_path.display(),
     )
 }


### PR DESCRIPTION
When the output is saved to a markdown file, e.g.:

```
pks --experimental-parser expose-monkey-patches \
--rubydir=/Users/alex.evanczuk/.rbenv/versions/3.2.2/lib/ruby/3.2.0/ \
--gemdir=/Users/alex.evanczuk/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/ \
> results.md
```

That markdown is a lot easier to read:
<img width="1453" alt="Screenshot 2023-08-02 at 10 51 41 PM" src="https://github.com/alexevanczuk/packs/assets/3311200/a3a68b81-48fb-49d1-a51f-70d910c538f4">

In the future, we could also add a `json` mode so the user can easily create their own formatters. For now, this is a helpful format to see the initial list.

# Commits
- make test fail
- make test pass
- bump version
