### PR TITLE
Fix incorrect version number listed in releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           # When there are no changes, VERSION_CHANGES will be empty
           # Without the echo, this command would exit with a 1, causing the GitHub Action to fail
           # Instead, we want it to succeed, but just evaluate `changed=false` in the other branch of the conditional
-          VERSION_CHANGES=$(git diff HEAD HEAD~1 Cargo.toml | grep "\+version" || echo "")
+          VERSION_CHANGES=$(git diff HEAD~1 HEAD Cargo.toml | grep "\+version" || echo "")
           if [[ -n $VERSION_CHANGES ]]; then
             NEW_VERSION=$(echo $VERSION_CHANGES | awk -F'"' '{print $2}')
             echo "changed=true" >> $GITHUB_OUTPUT

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.67"
+version = "0.1.68"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"


### PR DESCRIPTION
Fixes #107

# Commits
- bump version
- Diff HEAD~1 and HEAD in the correct order
