### PR TITLE
Run update tests in serial

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,4 @@ assert_cmd = "2.0.10" # testing CLI
 rusty-hook = "^0.11.2" # git hooks
 predicates = "3.0.2" # kind of like rspec assertions
 pretty_assertions = "1.3.0" # Shows a more readable diff when comparing objects
+serial_test = "~2.0" # Run specific tests in serial

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -1,10 +1,13 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
+use serial_test::serial;
 use std::{error::Error, path::Path, process::Command};
 mod common;
 use pretty_assertions::assert_eq;
 
 #[test]
+// This and the next test are run in serial because they both use the same fixtures.
+#[serial]
 fn test_update() -> Result<(), Box<dyn Error>> {
     Command::cargo_bin("packs")?
         .arg("--project-root")
@@ -48,6 +51,7 @@ packs/bar:
 }
 
 #[test]
+#[serial]
 fn test_update_with_experimental_parser() -> Result<(), Box<dyn Error>> {
     Command::cargo_bin("packs")
         .unwrap()


### PR DESCRIPTION
Helps resolve flaky test due to cleaning up a fixture-under-test while the other test is still running in parallel.

In the future, we can think of other designs to solve this non-determinism. For example:
- Each test gets its own fixture
- Testing something that doesn't mutate shared state
- etc.
