### PR TITLE
Providing descriptive panic message when a package.yml cannot be deserialized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.75"
+version = "0.1.76"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -278,4 +278,18 @@ packs/foo, packs/bar",
         let error = checker.validate(&configuration);
         assert_eq!(error, None);
     }
+
+    #[test]
+    #[should_panic(expected = "Failed to deserialize the YAML")]
+    fn test_invalid_package_yml() {
+        let checker = Checker {};
+        let configuration = configuration::get(
+            PathBuf::from("tests/fixtures/contains_duplicates_in_package")
+                .canonicalize()
+                .expect("Could not canonicalize path")
+                .as_path(),
+        );
+
+        checker.validate(&configuration);
+    }
 }

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -280,7 +280,7 @@ packs/foo, packs/bar",
     }
 
     #[test]
-    #[should_panic(expected = "Failed to deserialize the YAML")]
+    #[should_panic(expected = "tests/fixtures/contains_duplicates_in_package/packs/bar/package.yml")]
     fn test_invalid_package_yml() {
         let checker = Checker {};
         let configuration = configuration::get(

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -280,7 +280,9 @@ packs/foo, packs/bar",
     }
 
     #[test]
-    #[should_panic(expected = "tests/fixtures/contains_duplicates_in_package/packs/bar/package.yml")]
+    #[should_panic(
+        expected = "tests/fixtures/contains_duplicates_in_package/packs/bar/package.yml"
+    )]
     fn test_invalid_package_yml() {
         let checker = Checker {};
         let configuration = configuration::get(

--- a/src/packs/pack.rs
+++ b/src/packs/pack.rs
@@ -213,8 +213,16 @@ impl Pack {
         package_yml_contents: &str,
         package_todo: PackageTodo,
     ) -> Pack {
-        let pack: Pack = serde_yaml::from_str(package_yml_contents)
-            .expect("Failed to deserialize the YAML");
+        let pack_result = serde_yaml::from_str(package_yml_contents);
+        let pack: Pack = match pack_result {
+            Ok(pack) => pack,
+            Err(e) => {
+                panic!(
+                    "Failed to deserialize the YAML at {:?} with error: {:?}",
+                    package_yml_absolute_path, e
+                )
+            }
+        };
 
         let package_yml_relative_path = package_yml_absolute_path
             .strip_prefix(absolute_root)

--- a/tests/fixtures/contains_duplicates_in_package/packs/bar/app/models/concerns/some_concern.rb
+++ b/tests/fixtures/contains_duplicates_in_package/packs/bar/app/models/concerns/some_concern.rb
@@ -1,0 +1,1 @@
+module SomeConcern; end

--- a/tests/fixtures/contains_duplicates_in_package/packs/bar/app/services/bar.rb
+++ b/tests/fixtures/contains_duplicates_in_package/packs/bar/app/services/bar.rb
@@ -1,0 +1,3 @@
+module Bar
+  def bar; end
+end

--- a/tests/fixtures/contains_duplicates_in_package/packs/bar/package.yml
+++ b/tests/fixtures/contains_duplicates_in_package/packs/bar/package.yml
@@ -1,0 +1,5 @@
+enforce_privacy: true
+enforce_architecture: true
+enforce_architecture: true
+dependencies:
+- packs/foo

--- a/tests/fixtures/contains_duplicates_in_package/packs/foo/package.yml
+++ b/tests/fixtures/contains_duplicates_in_package/packs/foo/package.yml
@@ -1,0 +1,4 @@
+enforce_dependencies: true
+enforce_privacy: true
+dependencies:
+- packs/bar

--- a/tests/fixtures/contains_duplicates_in_package/packwerk.yml
+++ b/tests/fixtures/contains_duplicates_in_package/packwerk.yml
@@ -1,0 +1,23 @@
+# See: Setting up the configuration file
+# https://github.com/Shopify/packwerk/blob/main/USAGE.md#setting-up-the-configuration-file
+
+# List of patterns for folder paths to include
+# include:
+# - "**/*.{rb,rake,erb}"
+
+# List of patterns for folder paths to exclude
+# exclude:
+# - "{bin,node_modules,script,tmp,vendor}/**/*"
+
+# Patterns to find package configuration files
+# package_paths: "**/"
+
+# List of custom associations, if any
+# custom_associations:
+# - "cache_belongs_to"
+
+# Whether or not you want the cache enabled (disabled by default)
+cache: false
+
+# Where you want the cache to be stored (default below)
+# cache_directory: 'tmp/cache/packwerk'


### PR DESCRIPTION
Including the file name in the panic message.

Before
```
pks validate
thread 'main' panicked at src/packs/pack.rs:217:14:
Failed to deserialize the YAML: Error("duplicate field `enforce_architecture`", line: 1, column: 1)
```
After
```
thread 'main' panicked at src/packs/pack.rs:220:17:
Failed to deserialize the YAML at "/my/packs/foo/package.yml" with error: Error("duplicate field `enforce_architecture`", line: 1, column: 1)
```