### PR TITLE
Support custom root namespaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod test_util {
             &absolute_root,
             &configuration.cache_directory,
             true,
+            &configuration.autoload_roots,
         )
     }
 

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -235,6 +235,7 @@ pub(crate) fn list_definitions(configuration: &Configuration, ambiguous: bool) {
             &configuration.absolute_root,
             &configuration.cache_directory,
             !configuration.cache_enabled,
+            &configuration.autoload_roots,
         )
     };
 

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -258,7 +258,6 @@ mod tests {
     }
 
     fn build_foo_reference_bar_reference() -> Reference {
-        
         Reference {
             constant_name: String::from("::Bar"),
             defining_pack_name: Some(String::from("packs/bar")),

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -29,6 +29,7 @@ pub struct Configuration {
     pub layers: Layers,
     pub experimental_parser: bool,
     pub ignored_definitions: HashMap<String, HashSet<PathBuf>>,
+    pub autoload_roots: HashMap<PathBuf, String>,
     pub custom_associations: Vec<String>,
     pub stdin_file_path: Option<PathBuf>,
     // Note that it'd probably be better to use the logger library, `tracing` (see logger.rs)
@@ -108,6 +109,8 @@ pub(crate) fn from_raw(
     };
 
     let ignored_definitions = raw_config.ignored_definitions;
+    let autoload_roots: HashMap<PathBuf, String> = raw_config.autoload_roots;
+
     let packs_first_mode = raw_config.packs_first_mode;
 
     let custom_associations = raw_config
@@ -132,6 +135,7 @@ pub(crate) fn from_raw(
         layers,
         experimental_parser,
         ignored_definitions,
+        autoload_roots,
         custom_associations,
         stdin_file_path,
         print_files,
@@ -166,6 +170,7 @@ mod tests {
             absolute_root.join("packs/baz/app/services/baz.rb"),
             absolute_root.join("packs/bar/app/models/concerns/some_concern.rb"),
             absolute_root.join("app/services/some_root_class.rb"),
+            absolute_root.join("app/company_data/widget.rb"),
         ]
         .into_iter()
         .collect::<HashSet<PathBuf>>();
@@ -293,6 +298,7 @@ mod tests {
             absolute_root.join("packs/baz/app/services/baz.rb"),
             absolute_root.join("packs/bar/app/models/concerns/some_concern.rb"),
             absolute_root.join("app/services/some_root_class.rb"),
+            absolute_root.join("app/company_data/widget.rb"),
         ]
         .into_iter()
         .collect::<HashSet<PathBuf>>();

--- a/src/packs/pack.rs
+++ b/src/packs/pack.rs
@@ -615,7 +615,8 @@ owner: Foobar
             Pack::from_path(root.join("package.yml").as_path(), root.as_path());
 
         let actual = pack.default_autoload_roots();
-        let expected = vec![root.join("app/services")];
+        let expected =
+            vec![root.join("app/company_data"), root.join("app/services")];
         assert_eq!(expected, actual)
     }
 }

--- a/src/packs/parsing/ruby/packwerk.rs
+++ b/src/packs/parsing/ruby/packwerk.rs
@@ -486,7 +486,8 @@ end
         .unresolved_references;
 
         assert_eq!(references.len(), 1);
-        let reference = references.first()
+        let reference = references
+            .first()
             .expect("There should be a reference at index 0");
 
         assert_eq!(
@@ -516,7 +517,8 @@ end
         )
         .unresolved_references;
         assert_eq!(references.len(), 2);
-        let reference1 = references.first()
+        let reference1 = references
+            .first()
             .expect("There should be a reference at index 0");
 
         assert_eq!(
@@ -564,7 +566,8 @@ end
         )
         .unresolved_references;
         assert_eq!(references.len(), 1);
-        let reference = references.first()
+        let reference = references
+            .first()
             .expect("There should be a reference at index 0");
 
         assert_eq!(
@@ -595,7 +598,8 @@ end
         )
         .unresolved_references;
         assert_eq!(references.len(), 1);
-        let reference = references.first()
+        let reference = references
+            .first()
             .expect("There should be a reference at index 0");
 
         assert_eq!(
@@ -729,7 +733,8 @@ end
         )
         .unresolved_references;
         assert_eq!(references.len(), 2);
-        let first_reference = references.first()
+        let first_reference = references
+            .first()
             .expect("There should be a reference at index 0");
         assert_eq!(
             UnresolvedReference {
@@ -763,7 +768,8 @@ end
         )
         .unresolved_references;
         assert_eq!(references.len(), 1);
-        let first_reference = references.first()
+        let first_reference = references
+            .first()
             .expect("There should be a reference at index 0");
         assert_eq!(
             UnresolvedReference {
@@ -842,7 +848,8 @@ FOO = BAR
         .unresolved_references;
 
         assert_eq!(references.len(), 1);
-        let first_reference = references.first()
+        let first_reference = references
+            .first()
             .expect("There should be a reference at index 0");
 
         assert_eq!(
@@ -1257,7 +1264,8 @@ end
         )
         .unresolved_references;
         assert_eq!(references.len(), 2);
-        let first_reference = references.first()
+        let first_reference = references
+            .first()
             .expect("There should be a reference at index 0");
         let second_reference = references
             .get(1)
@@ -1285,7 +1293,8 @@ end
         )
         .unresolved_references;
         assert_eq!(references.len(), 1);
-        let reference = references.first()
+        let reference = references
+            .first()
             .expect("There should be a reference at index 0");
         assert_eq!(
             UnresolvedReference {

--- a/src/packs/raw_configuration.rs
+++ b/src/packs/raw_configuration.rs
@@ -60,6 +60,10 @@ pub(crate) struct RawConfiguration {
     #[serde(default)]
     pub ignored_definitions: HashMap<String, HashSet<PathBuf>>,
 
+    // Autoload paths used to resolve constants
+    #[serde(default)]
+    pub autoload_roots: HashMap<PathBuf, String>,
+
     // Use packs copy
     #[serde(default)]
     pub packs_first_mode: bool,

--- a/src/packs/reference_extractor.rs
+++ b/src/packs/reference_extractor.rs
@@ -52,6 +52,7 @@ pub(crate) fn get_all_references(
             &configuration.absolute_root,
             &configuration.cache_directory,
             !configuration.cache_enabled,
+            &configuration.autoload_roots,
         );
 
         (constant_resolver, processed_files)

--- a/tests/fixtures/simple_app/app/company_data/widget.rb
+++ b/tests/fixtures/simple_app/app/company_data/widget.rb
@@ -1,0 +1,3 @@
+module Company
+  class Widget end
+end

--- a/tests/fixtures/simple_app/packwerk.yml
+++ b/tests/fixtures/simple_app/packwerk.yml
@@ -19,5 +19,8 @@
 # Whether or not you want the cache enabled (disabled by default)
 cache: false
 
+autoload_roots:
+  app/company_data: "::Company"
+
 # Where you want the cache to be stored (default below)
 # cache_directory: 'tmp/cache/packwerk'


### PR DESCRIPTION
Zeitwerk [supports defining root namespaces](https://github.com/fxn/zeitwerk?tab=readme-ov-file#zeitwerkloaderdirs) for autoload root directories. For example, maybe you want to nest all constants defined in `app/services` under the `CompanyName` domain. Under this rule, Zeitwerk would expect a file called `app/services/widget_maker.rb` to define a constant `::CompanyName::WidgetMaker` rather than just `WidgetMaker`.

This pull request allows us to teach `packs` about the overridden namespaces via a new configuration key `namespace_overrides`. It takes the autoload root dirs as keys and the name of the custom root namespace as the values. So for the above example, you'd need to specify the following in `packwerk.yml`:

```
namespace_overrides:
  app/services: "::CompanyName"
```

Two things that might be improved:

* [x] The configuration could store the absolute autoload root directories instead of the relative directories. This would improve performance in the tight loop where we resolve constant definitions from file paths.
* [x] The `HashMap` could maybe use `PathBuf` or something instead of `String`? I don't know, it's been a long time and my Rust is quite... rusty. 🙈 

In addition to the above two things, we could benefit from wrapping a bunch of parameters being passed down from the config in some sort of abstraction. Five parameters is getting a bit much. I figured that is a good opportunity for a follow up PR.

Many many thanks for the help from @mathias and @bk2204 who were immensely helpful when my Rust memory was failing.

This PR goes a long way to getting Packs support for the GitHub monolith, but we still have some work to do! I'd say 90%+ of remaining differences between Packs and Packwerk for the GitHub monolith are resolved with this change.