### PR TITLE
Do not ignore "frontend" dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.83"
+version = "0.1.84"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -163,6 +163,7 @@ mod tests {
         assert_eq!(actual.absolute_root, absolute_root);
 
         let expected_included_files = vec![
+            absolute_root.join("frontend/ui_helper.rb"),
             absolute_root.join("packs/bar/app/services/bar.rb"),
             absolute_root.join("packs/foo/app/services/foo.rb"),
             absolute_root.join("packs/foo/app/services/foo/bar.rb"),
@@ -291,6 +292,7 @@ mod tests {
         let configuration = configuration::get(&absolute_root);
         let actual_paths = configuration.intersect_files(vec![]);
         let expected_paths = vec![
+            absolute_root.join("frontend/ui_helper.rb"),
             absolute_root.join("packs/bar/app/services/bar.rb"),
             absolute_root.join("packs/foo/app/services/foo.rb"),
             absolute_root.join("packs/foo/app/services/foo/bar.rb"),

--- a/src/packs/walk_directory.rs
+++ b/src/packs/walk_directory.rs
@@ -54,7 +54,6 @@ pub(crate) fn walk_directory(
         "public/**/*",
         "bin/**/*",
         "log/**/*",
-        "frontend/**/**",
         "sorbet/**/*",
     ];
     let mut all_excluded_dirs: Vec<String> = Vec::new();

--- a/tests/fixtures/simple_app/frontend/ui_helper.rb
+++ b/tests/fixtures/simple_app/frontend/ui_helper.rb
@@ -1,0 +1,5 @@
+module UiHelper
+  def self.help
+    "I'm a helper"
+  end
+end


### PR DESCRIPTION
**Background**:
We have a monolith containing ruby code in a top-level directory named `frontend`.

`packwerk check` includes `frontend` when looking for violations. 

**Change**
Do not ignore `frontend` by default. Developers can use the `packwerk.yml` -> `exclude:` section to ignore `frontend` if necessary.