### PR TITLE
Support custom inflections file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,7 @@ mod test_util {
 
         get_zeitwerk_constant_resolver(
             &configuration.pack_set,
-            &absolute_root,
-            &configuration.cache_directory,
-            true,
-            &configuration.autoload_roots,
+            &configuration.constant_resolver_configuration(),
         )
     }
 

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -232,10 +232,7 @@ pub(crate) fn list_definitions(configuration: &Configuration, ambiguous: bool) {
         }
         get_zeitwerk_constant_resolver(
             &configuration.pack_set,
-            &configuration.absolute_root,
-            &configuration.cache_directory,
-            !configuration.cache_enabled,
-            &configuration.autoload_roots,
+            &configuration.constant_resolver_configuration(),
         )
     };
 

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -29,6 +29,7 @@ pub struct Configuration {
     pub experimental_parser: bool,
     pub ignored_definitions: HashMap<String, HashSet<PathBuf>>,
     pub autoload_roots: HashMap<PathBuf, String>,
+    pub inflections_path: PathBuf,
     pub custom_associations: Vec<String>,
     pub stdin_file_path: Option<PathBuf>,
     // Note that it'd probably be better to use the logger library, `tracing` (see logger.rs)
@@ -82,6 +83,7 @@ impl Configuration {
             cache_directory: &self.cache_directory,
             cache_enabled: self.cache_enabled,
             autoload_roots: &self.autoload_roots,
+            inflections_path: &self.inflections_path,
         }
     }
 }
@@ -123,6 +125,12 @@ pub(crate) fn from_raw(
 
     let packs_first_mode = raw_config.packs_first_mode;
 
+    let inflections_path = absolute_root.join(
+        raw_config
+            .inflections_path
+            .unwrap_or(PathBuf::from("config/initializers/inflections.rb")),
+    );
+
     let custom_associations = raw_config
         .custom_associations
         .iter()
@@ -146,6 +154,7 @@ pub(crate) fn from_raw(
         experimental_parser,
         ignored_definitions,
         autoload_roots,
+        inflections_path,
         custom_associations,
         stdin_file_path,
         print_files,

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -1,17 +1,15 @@
-use super::caching::cache::Cache;
-use super::caching::create_cache_dir_idempotently;
-use super::caching::noop_cache::NoopCache;
-use super::caching::per_file_cache::PerFileCache;
+use super::caching::{
+    cache::Cache, create_cache_dir_idempotently, noop_cache::NoopCache,
+    per_file_cache::PerFileCache,
+};
 use super::checker::architecture::Layers;
 use super::file_utils::user_inputted_paths_to_absolute_filepaths;
-use super::raw_configuration::RawConfiguration;
-use super::constant_resolver::ConstantResolverConfiguration;
-use super::PackSet;
 
-use crate::packs::raw_configuration;
-use crate::packs::walk_directory::WalkDirectoryResult;
-
-use crate::packs::walk_directory;
+use super::{
+    constant_resolver::ConstantResolverConfiguration, raw_configuration,
+    raw_configuration::RawConfiguration, walk_directory,
+    walk_directory::WalkDirectoryResult, PackSet,
+};
 
 use std::collections::HashMap;
 use std::{

--- a/src/packs/configuration.rs
+++ b/src/packs/configuration.rs
@@ -5,6 +5,7 @@ use super::caching::per_file_cache::PerFileCache;
 use super::checker::architecture::Layers;
 use super::file_utils::user_inputted_paths_to_absolute_filepaths;
 use super::raw_configuration::RawConfiguration;
+use super::constant_resolver::ConstantResolverConfiguration;
 use super::PackSet;
 
 use crate::packs::raw_configuration;
@@ -72,6 +73,17 @@ impl Configuration {
             Box::new(PerFileCache { cache_dir })
         } else {
             Box::new(NoopCache {})
+        }
+    }
+
+    pub(crate) fn constant_resolver_configuration(
+        &self,
+    ) -> ConstantResolverConfiguration {
+        ConstantResolverConfiguration {
+            absolute_root: &self.absolute_root,
+            cache_directory: &self.cache_directory,
+            cache_enabled: self.cache_enabled,
+            autoload_roots: &self.autoload_roots,
         }
     }
 }

--- a/src/packs/constant_resolver.rs
+++ b/src/packs/constant_resolver.rs
@@ -8,6 +8,14 @@ pub struct ConstantDefinition {
     pub absolute_path_of_definition: PathBuf,
 }
 
+#[derive(Debug)]
+pub struct ConstantResolverConfiguration<'a> {
+    pub absolute_root: &'a PathBuf,
+    pub cache_directory: &'a PathBuf,
+    pub cache_enabled: bool,
+    pub autoload_roots: &'a HashMap<PathBuf, String>,
+}
+
 pub trait ConstantResolver {
     fn resolve(
         &self,

--- a/src/packs/constant_resolver.rs
+++ b/src/packs/constant_resolver.rs
@@ -13,6 +13,7 @@ pub struct ConstantResolverConfiguration<'a> {
     pub absolute_root: &'a PathBuf,
     pub cache_directory: &'a PathBuf,
     pub cache_enabled: bool,
+    pub inflections_path: &'a PathBuf,
     pub autoload_roots: &'a HashMap<PathBuf, String>,
 }
 

--- a/src/packs/parsing/ruby/rails_utils.rs
+++ b/src/packs/parsing/ruby/rails_utils.rs
@@ -7,11 +7,11 @@ use regex::Regex;
 // An inflection takes the form of "inflect.acronym 'API'", so "API" would be the acronym here
 // This is a bit of a hack, but it's the easiest way to get the inflections loaded in
 // TODO: Figure out a better way to do this
-pub(crate) fn get_acronyms_from_disk(absolute_root: &Path) -> HashSet<String> {
+pub(crate) fn get_acronyms_from_disk(
+    inflections_path: &Path,
+) -> HashSet<String> {
     let mut acronyms: HashSet<String> = HashSet::new();
 
-    let inflections_path =
-        absolute_root.join("config/initializers/inflections.rb");
     if inflections_path.exists() {
         let inflections_file =
             std::fs::read_to_string(inflections_path).unwrap();

--- a/src/packs/parsing/ruby/zeitwerk/mod.rs
+++ b/src/packs/parsing/ruby/zeitwerk/mod.rs
@@ -11,7 +11,9 @@ use tracing::debug;
 
 use crate::packs::{
     caching::create_cache_dir_idempotently,
-    constant_resolver::{ConstantDefinition, ConstantResolver},
+    constant_resolver::{
+        ConstantDefinition, ConstantResolver, ConstantResolverConfiguration,
+    },
     file_utils::expand_glob,
     parsing::ruby::rails_utils::get_acronyms_from_disk,
     PackSet,
@@ -23,31 +25,19 @@ use super::inflector_shim;
 
 pub fn get_zeitwerk_constant_resolver(
     pack_set: &PackSet,
-    absolute_root: &Path,
-    cache_dir: &Path,
-    cache_disabled: bool,
-    autoload_root_globs: &HashMap<PathBuf, String>,
+    configuration: &ConstantResolverConfiguration,
 ) -> Box<dyn ConstantResolver + Send + Sync> {
-    let constants = inferred_constants_from_pack_set(
-        pack_set,
-        absolute_root,
-        cache_dir,
-        cache_disabled,
-        autoload_root_globs,
-    );
+    let constants = inferred_constants_from_pack_set(pack_set, configuration);
 
     ZeitwerkConstantResolver::create(constants)
 }
 
 fn inferred_constants_from_pack_set(
     pack_set: &PackSet,
-    absolute_root: &Path,
-    cache_dir: &Path,
-    cache_disabled: bool,
-    autoload_root_globs: &HashMap<PathBuf, String>,
+    configuration: &ConstantResolverConfiguration,
 ) -> Vec<ConstantDefinition> {
     // build the full list of default autoload roots from the pack set, using the default namespace for each.
-    let mut autoload_roots: HashMap<PathBuf, String> = pack_set
+    let mut full_autoload_roots: HashMap<PathBuf, String> = pack_set
         .packs
         .iter()
         .flat_map(|pack| pack.default_autoload_roots())
@@ -55,40 +45,36 @@ fn inferred_constants_from_pack_set(
         .collect();
 
     // override the default autoload roots with any that may have been explicitly specified.
-    autoload_root_globs.iter().for_each(|(rel_path, ns)| {
-        let abs_path = absolute_root.join(rel_path);
-        let ns = if ns == "::Object" {
-            String::from("")
-        } else {
-            ns.to_owned()
-        };
-        expand_glob(abs_path.to_str().unwrap())
-            .iter()
-            .for_each(|path| {
-                autoload_roots.insert(path.to_owned(), ns.clone());
-            });
-    });
+    configuration
+        .autoload_roots
+        .iter()
+        .for_each(|(rel_path, ns)| {
+            let abs_path = configuration.absolute_root.join(rel_path);
+            let ns = if ns == "::Object" {
+                String::from("")
+            } else {
+                ns.to_owned()
+            };
+            expand_glob(abs_path.to_str().unwrap())
+                .iter()
+                .for_each(|path| {
+                    full_autoload_roots.insert(path.to_owned(), ns.clone());
+                });
+        });
 
-    inferred_constants_from_autoload_paths(
-        autoload_roots,
-        absolute_root,
-        cache_dir,
-        cache_disabled,
-    )
+    inferred_constants_from_autoload_paths(configuration, full_autoload_roots)
 }
 
 fn inferred_constants_from_autoload_paths(
-    autoload_roots: HashMap<PathBuf, String>,
-    absolute_root: &Path,
-    cache_dir: &Path,
-    cache_disabled: bool,
+    configuration: &ConstantResolverConfiguration,
+    full_autoload_roots: HashMap<PathBuf, String>,
 ) -> Vec<ConstantDefinition> {
     debug!("Get constant resolver cache");
-    let cache_data = get_constant_resolver_cache(cache_dir);
+    let cache_data = get_constant_resolver_cache(configuration.cache_directory);
 
     debug!("Globbing out autoload paths");
     // First, we get a map of each autoload path to the files they map to.
-    let autoload_paths_to_their_globbed_files = autoload_roots
+    let autoload_paths_to_their_globbed_files = full_autoload_roots
         .keys()
         .par_bridge()
         .map(|absolute_autoload_path| {
@@ -131,7 +117,7 @@ fn inferred_constants_from_autoload_paths(
     }
 
     debug!("Getting acronyms from disk");
-    let acronyms = &get_acronyms_from_disk(absolute_root);
+    let acronyms = &get_acronyms_from_disk(&configuration.absolute_root);
 
     debug!("Inferring constants from file name (using cache)");
     let constants: Vec<ConstantDefinition> = file_to_longest_path
@@ -149,7 +135,7 @@ fn inferred_constants_from_autoload_paths(
                 }
             } else {
                 let default_namespace =
-                    autoload_roots.get(absolute_autoload_path).unwrap();
+                    full_autoload_roots.get(absolute_autoload_path).unwrap();
                 inferred_constant_from_file(
                     absolute_path_of_definition,
                     absolute_autoload_path,
@@ -161,7 +147,11 @@ fn inferred_constants_from_autoload_paths(
         .collect::<Vec<ConstantDefinition>>();
 
     debug!("Caching constant definitions");
-    cache_constant_definitions(&constants, cache_dir, cache_disabled);
+    cache_constant_definitions(
+        &constants,
+        configuration.cache_directory,
+        !configuration.cache_enabled,
+    );
 
     constants
 }
@@ -390,14 +380,9 @@ mod tests {
 
         let configuration = configuration::get(absolute_root);
 
-        let pack_set = configuration.pack_set;
-
         let constant_resolver = get_zeitwerk_constant_resolver(
-            &pack_set,
-            absolute_root,
-            &configuration.cache_directory,
-            !configuration.cache_enabled,
-            &configuration.autoload_roots,
+            &configuration.pack_set,
+            &configuration.constant_resolver_configuration(),
         );
         let actual_constant_map = constant_resolver
             .fully_qualified_constant_name_to_constant_definition_map();

--- a/src/packs/parsing/ruby/zeitwerk/mod.rs
+++ b/src/packs/parsing/ruby/zeitwerk/mod.rs
@@ -117,7 +117,7 @@ fn inferred_constants_from_autoload_paths(
     }
 
     debug!("Getting acronyms from disk");
-    let acronyms = &get_acronyms_from_disk(&configuration.absolute_root);
+    let acronyms = &get_acronyms_from_disk(configuration.inflections_path);
 
     debug!("Inferring constants from file name (using cache)");
     let constants: Vec<ConstantDefinition> = file_to_longest_path

--- a/src/packs/raw_configuration.rs
+++ b/src/packs/raw_configuration.rs
@@ -64,6 +64,10 @@ pub(crate) struct RawConfiguration {
     #[serde(default)]
     pub autoload_roots: HashMap<PathBuf, String>,
 
+    // Relative path to inflections file
+    #[serde(default)]
+    pub inflections_path: Option<PathBuf>,
+
     // Use packs copy
     #[serde(default)]
     pub packs_first_mode: bool,

--- a/src/packs/reference_extractor.rs
+++ b/src/packs/reference_extractor.rs
@@ -49,10 +49,7 @@ pub(crate) fn get_all_references(
         // The zeitwerk constant resolver doesn't look at processed files to get definitions
         let constant_resolver = get_zeitwerk_constant_resolver(
             &configuration.pack_set,
-            &configuration.absolute_root,
-            &configuration.cache_directory,
-            !configuration.cache_enabled,
-            &configuration.autoload_roots,
+            &configuration.constant_resolver_configuration(),
         );
 
         (constant_resolver, processed_files)


### PR DESCRIPTION
In our monolith we have a custom name for our inflections file. As `packs` currently hard codes the inflections file to `config/initializers/inflections.rb`, our inflections are missed. This PR adds a new configuration parameter that allows users to specify an `inflections_path`.

This PR is best reviewed commit-by-commit. The first commit is most significant and refactors our parameters and creates a new `ConstantResolverConfiguration` struct to encapsulate the relevant parameters that are always passed around as a group anyway. The last commit adds the new `inflections_path` property and is pretty simple.

My only thought about this change is it might be better named `ConstantResolver::Configuration` but embarrassingly enough I wasn't sure the "right" way to do this and I wasn't sure about it anyway.