### PR TITLE
Adding validation errors for self-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.85"
+version = "0.1.86"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/tests/fixtures/app_with_dependency_cycles/packs/baz/package.yml
+++ b/tests/fixtures/app_with_dependency_cycles/packs/baz/package.yml
@@ -1,0 +1,4 @@
+enforce_dependencies: true
+enforce_privacy: true
+dependencies:
+- packs/baz

--- a/tests/validate_test.rs
+++ b/tests/validate_test.rs
@@ -22,8 +22,11 @@ packs/foo, packs/bar",
         .arg("validate")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("1 validation error(s) detected:"))
-        .stdout(predicate::str::contains(expected_message));
+        .stdout(predicate::str::contains("2 validation error(s) detected:"))
+        .stdout(predicate::str::contains(expected_message))
+        .stdout(predicate::str::contains(
+            "Package cannot list itself as a dependency: packs/baz/package.yml",
+        ));
 
     common::teardown();
     Ok(())


### PR DESCRIPTION
**Context:**
`packwerk` reports a validation error if a pack lists itself as a dependency.

pack/foo/package.yml
```yml
dependencies:
  - packs/foo
```
However, the rust equivalent does not.

**Change:**
When a package.yml lists itself as dependency, `pks validate` now prints "Package cannot list itself as a dependency: packs/foo/package.yml"