### PR TITLE
Update dependencies for constant

### DIFF
--- a/src/packs.rs
+++ b/src/packs.rs
@@ -177,6 +177,13 @@ pub fn check_unnecessary_dependencies(
     }
 }
 
+pub fn update_dependencies_for_constant(
+    configuration: &Configuration,
+    constant: String,
+) -> anyhow::Result<()> {
+    todo!()
+}
+
 pub fn list(configuration: Configuration) {
     for pack in configuration.pack_set.packs {
         println!("{}", pack.yml.display())

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -13,6 +13,7 @@ pub(crate) mod parsing;
 pub(crate) mod raw_configuration;
 pub(crate) mod walk_directory;
 
+mod constant_dependencies;
 mod file_utils;
 mod logger;
 mod pack_set;
@@ -179,9 +180,31 @@ pub fn check_unnecessary_dependencies(
 
 pub fn update_dependencies_for_constant(
     configuration: &Configuration,
-    constant: String,
+    constant_name: &str,
 ) -> anyhow::Result<()> {
-    todo!()
+    match constant_dependencies::update_dependencies_for_constant(
+        configuration,
+        constant_name,
+    ) {
+        Ok(num_updated) => {
+            match num_updated {
+                0 => println!(
+                    "No dependencies to update for constant '{}'",
+                    constant_name
+                ),
+                1 => println!(
+                    "Successfully updated 1 dependency for constant '{}'",
+                    constant_name
+                ),
+                _ => println!(
+                    "Successfully updated {} dependencies for constant '{}'",
+                    num_updated, constant_name
+                ),
+            }
+            Ok(())
+        }
+        Err(err) => Err(anyhow::anyhow!(err)),
+    }
 }
 
 pub fn list(configuration: Configuration) {

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -80,6 +80,14 @@ enum Command {
     },
 
     #[clap(
+        about = "Add missing dependencies to packs referencing the supplied constant"
+    )]
+    UpdateDependenciesForConstant {
+        /// Update every pack that references this constant
+        constant: String,
+    },
+
+    #[clap(
         about = "Check for dependencies that when removed produce no violations."
     )]
     CheckUnnecessaryDependencies {
@@ -206,6 +214,9 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
         Command::CheckUnnecessaryDependencies { auto_correct } => {
             packs::check_unnecessary_dependencies(&configuration, auto_correct)
         }
+        Command::UpdateDependenciesForConstant { constant } => Ok(
+            packs::update_dependencies_for_constant(&configuration, constant)?,
+        ),
         Command::DeleteCache => {
             packs::delete_cache(configuration);
             Ok(())

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -80,7 +80,7 @@ enum Command {
     },
 
     #[clap(
-        about = "Add missing dependencies to packs referencing the supplied constant"
+        about = "Add missing depedencies for the pack that defines the constant"
     )]
     UpdateDependenciesForConstant {
         /// Update every pack that references this constant
@@ -215,7 +215,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
             packs::check_unnecessary_dependencies(&configuration, auto_correct)
         }
         Command::UpdateDependenciesForConstant { constant } => Ok(
-            packs::update_dependencies_for_constant(&configuration, constant)?,
+            packs::update_dependencies_for_constant(&configuration, &constant)?,
         ),
         Command::DeleteCache => {
             packs::delete_cache(configuration);

--- a/src/packs/constant_dependencies.rs
+++ b/src/packs/constant_dependencies.rs
@@ -1,0 +1,234 @@
+use anyhow::Context;
+
+use crate::packs::{
+    checker::reference::Reference, pack::write_pack_to_disk,
+    reference_extractor::get_all_references,
+};
+
+use super::{pack::Pack, Configuration};
+use std::collections::HashSet;
+
+/// Finds references to the provided constant and updates the associated packs to include the defining pack as a dependency.
+pub fn update_dependencies_for_constant(
+    configuration: &Configuration,
+    constant_name: &str,
+) -> anyhow::Result<usize> {
+    let all_references =
+        get_all_references(configuration, &configuration.included_files);
+    if let Some((defining_pack_name, reference_pack_names_set)) =
+        find_defining_and_referencing_packs(&all_references, constant_name)
+    {
+        let packs_for_update = find_pack_names_for_update(
+            configuration,
+            &defining_pack_name,
+            &reference_pack_names_set,
+        )?;
+        let defining_pack = configuration
+            .pack_set
+            .for_pack(&defining_pack_name)
+            .context("Could not find the defining pack")?;
+
+        for pack in packs_for_update.iter() {
+            let cloned_pack = pack.add_dependency(defining_pack);
+            write_pack_to_disk(&cloned_pack);
+        }
+
+        Ok(packs_for_update.len())
+    } else {
+        Ok(0)
+    }
+}
+
+fn find_pack_names_for_update<'a>(
+    configuration: &'a Configuration,
+    defining_pack_name: &'a str,
+    reference_pack_names_set: &'a HashSet<String>,
+) -> anyhow::Result<Vec<&'a Pack>> {
+    let packs_for_update: Vec<&Pack> = reference_pack_names_set
+        .iter()
+        .filter_map(|referencing_pack_name| {
+            let referencing_pack = configuration
+                .pack_set
+                .for_pack(referencing_pack_name)
+                .context("Could not find the referencing pack")
+                .ok()?;
+            if referencing_pack.dependencies.contains(defining_pack_name) {
+                None
+            } else {
+                Some(referencing_pack)
+            }
+        })
+        .collect();
+    Ok(packs_for_update)
+}
+
+fn find_defining_and_referencing_packs(
+    all_references: &[Reference],
+    constant_name: &str,
+) -> Option<(String, HashSet<String>)> {
+    let mut defining_pack_name_option: Option<&str> = None;
+    let reference_pack_names_set: HashSet<&String> = all_references
+        .iter()
+        .filter_map(|reference| {
+            if reference.constant_name == constant_name {
+                if let Some(defining_pack_name) = &reference.defining_pack_name
+                {
+                    if defining_pack_name != &reference.referencing_pack_name {
+                        defining_pack_name_option
+                            .get_or_insert(defining_pack_name);
+                        return Some(&reference.referencing_pack_name);
+                    }
+                }
+            }
+            None
+        })
+        .collect();
+    defining_pack_name_option.map(|defining_pack_name| {
+        (
+            defining_pack_name.to_string(),
+            reference_pack_names_set
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::packs::{PackSet, SourceLocation};
+
+    fn example_references() -> Vec<Reference> {
+        vec![
+            Reference {
+                constant_name: String::from("::Bar::BarChild"),
+                defining_pack_name: Some(String::from("packs/bar")),
+                referencing_pack_name: String::from("packs/foo"),
+                relative_referencing_file: String::from(
+                    "packs/foo/app/services/foo.rb",
+                ),
+                relative_defining_file: Some(String::from(
+                    "packs/bar/app/api/bar.rb",
+                )),
+                source_location: SourceLocation { line: 3, column: 1 },
+            },
+            Reference {
+                constant_name: String::from("::Bar::BarChild"),
+                defining_pack_name: Some(String::from("packs/bar")),
+                referencing_pack_name: String::from("packs/bar"),
+                relative_referencing_file: String::from(
+                    "packs/bar/app/services/foo.rb",
+                ),
+                relative_defining_file: Some(String::from(
+                    "packs/bar/app/api/bar.rb",
+                )),
+                source_location: SourceLocation { line: 3, column: 1 },
+            },
+            Reference {
+                constant_name: String::from("::BarChild"),
+                defining_pack_name: Some(String::from("packs/diff_bar")),
+                referencing_pack_name: String::from("packs/baz"),
+                relative_referencing_file: String::from(
+                    "packs/baz/app/services/baz.rb",
+                ),
+                relative_defining_file: Some(String::from(
+                    "packs/diff_bar/app/api/diff_bar.rb",
+                )),
+                source_location: SourceLocation {
+                    line: 33,
+                    column: 1,
+                },
+            },
+            Reference {
+                constant_name: String::from("::Bar"),
+                defining_pack_name: Some(String::from("packs/bar")),
+                referencing_pack_name: String::from("packs/bizz"),
+                relative_referencing_file: String::from(
+                    "packs/bizz/app/services/baz.rb",
+                ),
+                relative_defining_file: Some(String::from(
+                    "packs/bar/app/api/bar.rb",
+                )),
+                source_location: SourceLocation {
+                    line: 53,
+                    column: 1,
+                },
+            },
+        ]
+    }
+
+    #[test]
+    fn test_find_defining_and_referencing_packs() {
+        let references = example_references();
+        let (defining_pack_name, reference_pack_names_set) =
+            find_defining_and_referencing_packs(&references, "::Bar::BarChild")
+                .unwrap();
+        assert_eq!(defining_pack_name, "packs/bar");
+        assert_eq!(reference_pack_names_set.len(), 1);
+        assert!(reference_pack_names_set.contains("packs/foo"));
+    }
+
+    #[test]
+    fn test_find_defining_and_referencing_packs_when_constant_not_found() {
+        let references = example_references();
+        let result =
+            find_defining_and_referencing_packs(&references, "NonExistent");
+        assert!(result.is_none());
+    }
+
+    fn example_configuration() -> Configuration {
+        let defining_pack = Pack {
+            name: String::from("packs/foo"),
+            ..Pack::default()
+        };
+        let referencing_pack_bar = Pack {
+            name: String::from("packs/bar"),
+            ..Pack::default()
+        };
+        let referencing_pack_baz = Pack {
+            name: String::from("packs/baz"),
+            dependencies: HashSet::from_iter(vec![String::from("packs/foo")]),
+            ..Pack::default()
+        };
+
+        let root_pack = Pack {
+            name: String::from("."),
+            ..Pack::default()
+        };
+        Configuration {
+            pack_set: PackSet::build(
+                HashSet::from_iter(vec![
+                    root_pack,
+                    defining_pack,
+                    referencing_pack_bar,
+                    referencing_pack_baz,
+                ]),
+                HashMap::new(),
+            ),
+            ..Configuration::default()
+        }
+    }
+
+    #[test]
+    fn test_find_pack_names_for_update() {
+        let configuration = example_configuration();
+
+        let reference_pack_names_set = HashSet::from_iter(vec![
+            String::from("packs/bar"),
+            String::from("packs/baz"),
+            String::from("packs/does-not-exist"),
+        ]);
+
+        let packs_for_update = find_pack_names_for_update(
+            &configuration,
+            "packs/foo",
+            &reference_pack_names_set,
+        );
+        let packs_for_update = packs_for_update.unwrap();
+        assert_eq!(packs_for_update.len(), 1);
+        assert_eq!(packs_for_update[0].name, "packs/bar");
+    }
+}

--- a/tests/add_constant_dependencies.rs
+++ b/tests/add_constant_dependencies.rs
@@ -1,0 +1,57 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use pretty_assertions::assert_eq;
+use serial_test::serial;
+use std::{collections::HashSet, error::Error, path::PathBuf};
+
+mod common;
+
+#[test]
+#[serial]
+fn test_add_constant_dependencies() -> anyhow::Result<()> {
+    Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg("tests/fixtures/app_with_missing_dependencies")
+        .arg("update-dependencies-for-constant")
+        .arg("::Bar::Tender")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Successfully updated 1 dependency for constant '::Bar::Tender'",
+        ));
+
+    let config = packs::packs::configuration(PathBuf::from(
+        "tests/fixtures/app_with_missing_dependencies",
+    ));
+
+    let pack = config.pack_set.for_pack("packs/foo").unwrap();
+    assert_eq!(pack.dependencies.len(), 0);
+
+    let pack = config.pack_set.for_pack("packs/baz").unwrap();
+    assert_eq!(pack.dependencies.len(), 1);
+
+    let mut expected = HashSet::new();
+    expected.insert("packs/bar".to_owned());
+    assert_eq!(pack.dependencies, expected);
+    common::teardown();
+    common::set_up_fixtures();
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_add_constant_dependencies_no_dependencies() -> anyhow::Result<()> {
+    Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg("tests/fixtures/app_with_missing_dependencies")
+        .arg("update-dependencies-for-constant")
+        .arg("::Bar::Nope")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No dependencies to update for constant '::Bar::Nope'",
+        ));
+
+    Ok(())
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -135,4 +135,15 @@ dependencies:
     );
 
     fs::write(pack_yml, pack_yml_contents).unwrap();
+
+    let pack_yml = PathBuf::from(
+        "tests/fixtures/app_with_missing_dependencies/packs/baz/package.yml",
+    );
+    let pack_yml_contents = String::from(
+        "\
+enforce_dependencies: true
+",
+    );
+
+    fs::write(pack_yml, pack_yml_contents).unwrap();
 }

--- a/tests/fixtures/app_with_missing_dependencies/packs/bar/app/public/bar/tender.rb
+++ b/tests/fixtures/app_with_missing_dependencies/packs/bar/app/public/bar/tender.rb
@@ -1,0 +1,7 @@
+module Bar
+  module Tender
+    def self.call
+      'bar::tender'
+    end
+  end
+end

--- a/tests/fixtures/app_with_missing_dependencies/packs/bar/package.yml
+++ b/tests/fixtures/app_with_missing_dependencies/packs/bar/package.yml
@@ -1,0 +1,3 @@
+enforce_dependencies: true
+dependencies:
+  - packs/bar

--- a/tests/fixtures/app_with_missing_dependencies/packs/baz/app/services/baz/patron.rb
+++ b/tests/fixtures/app_with_missing_dependencies/packs/baz/app/services/baz/patron.rb
@@ -1,0 +1,7 @@
+module Baz
+  module Patron
+    def self.call
+      Bar::Tender.call
+    end
+  end
+end

--- a/tests/fixtures/app_with_missing_dependencies/packs/baz/package.yml
+++ b/tests/fixtures/app_with_missing_dependencies/packs/baz/package.yml
@@ -1,0 +1,1 @@
+enforce_dependencies: true

--- a/tests/fixtures/app_with_missing_dependencies/packs/foo/app/services/foo/no_bar.rb
+++ b/tests/fixtures/app_with_missing_dependencies/packs/foo/app/services/foo/no_bar.rb
@@ -1,0 +1,7 @@
+module Foo
+  module NoBar
+    def self.call
+      'foo::no_bar'
+    end
+  end
+end

--- a/tests/fixtures/app_with_missing_dependencies/packs/foo/package.yml
+++ b/tests/fixtures/app_with_missing_dependencies/packs/foo/package.yml
@@ -1,0 +1,2 @@
+enforce_dependencies: true
+

--- a/tests/fixtures/app_with_missing_dependencies/packwerk.yml
+++ b/tests/fixtures/app_with_missing_dependencies/packwerk.yml
@@ -1,0 +1,1 @@
+cache: false


### PR DESCRIPTION
**Context**
Say you moved a private constant `::Foo::Bar` to `app/public` in your `packs/foo` pack and other packs already refer to it. Without this change, you would need to track down all references to `::Foo::Bar` and add `packs/foo` to their `package.yml` dependencies.

**The Change**
`packs update-dependencies-for-constant ::Foo::Bar` will add a `packs/foo` dependency to all the applicable `package.yml` files