### PR TITLE
Initial pass at an `init` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -50,7 +50,7 @@ pub fn greet() {
 }
 
 
-pub fn init(path: &PathBuf) {
+pub fn init(absolute_root: &PathBuf) -> anyhow::Result<()> {
     let root_package = "\
 # This file represents the root package of the application
 # Please validate the configuration using `packwerk validate` (for Rails applications) or running the auto generated
@@ -89,12 +89,23 @@ enforce_dependencies: false
 # Where you want the cache to be stored (default below)
 # cache_directory: \"tmp/cache/packwerk\"
 ";
-    let root_package_path = path.join("package.yml");
-    let packs_config_path = path.join("packwerk.yml"); // Can you just create a packs.yml?
+    let root_package_path = absolute_root.join("package.yml");
+    let packs_config_path = absolute_root.join("packwerk.yml"); // Can you just create a packs.yml?
+
+    if root_package_path.exists() {
+        println!("`{}` already exists!", root_package_path.display());
+        bail!("Could not initialize package.yml")
+    }
+    if packs_config_path.exists() {
+        println!("`{}` already exists!", packs_config_path.display());
+        bail!("Could not initialize packwerk.yml")
+    }
+
     std::fs::write(root_package_path.clone(), root_package).unwrap();
     std::fs::write(packs_config_path.clone(), packs_config).unwrap();
 
-    println!("Creating '{}' and '{}'", packs_config_path.display(), root_package_path.display());
+    println!("Created '{}' and '{}'", packs_config_path.display(), root_package_path.display());
+    return Ok(());
 }
 
 fn create(configuration: &Configuration, name: String) -> anyhow::Result<()> {

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -49,6 +49,54 @@ pub fn greet() {
     println!("👋 Hello! Welcome to packs 📦 🔥 🎉 🌈. This tool is under construction.")
 }
 
+
+pub fn init(path: &PathBuf) {
+    let root_package = "\
+# This file represents the root package of the application
+# Please validate the configuration using `packwerk validate` (for Rails applications) or running the auto generated
+# test case (for non-Rails projects). You can then use `packwerk check` to check your code.
+
+# Change to `true` to turn on dependency checks for this package
+enforce_dependencies: false
+
+# A list of this package's dependencies
+# Note that packages in this list require their own `package.yml` file
+# dependencies:
+# - \"packages/billing\"
+";
+    let packs_config = "\
+# See: Setting up the configuration file
+# https://github.com/Shopify/packwerk/blob/main/USAGE.md#configuring-packwerk
+
+# List of patterns for folder paths to include
+# include:
+# - \"**/*.{rb,rake,erb}\"
+
+# List of patterns for folder paths to exclude
+# exclude:
+# - \"{bin,node_modules,script,tmp,vendor}/**/*\"
+
+# Patterns to find package configuration files
+# package_paths: \"**/\"
+
+# List of custom associations, if any
+# custom_associations:
+# - \"cache_belongs_to\"
+
+# Whether or not you want the cache enabled (disabled by default)
+# cache: true
+
+# Where you want the cache to be stored (default below)
+# cache_directory: \"tmp/cache/packwerk\"
+";
+    let root_package_path = path.join("package.yml");
+    let packs_config_path = path.join("packwerk.yml"); // Can you just create a packs.yml?
+    std::fs::write(root_package_path.clone(), root_package).unwrap();
+    std::fs::write(packs_config_path.clone(), packs_config).unwrap();
+
+    println!("Creating '{}' and '{}'", packs_config_path.display(), root_package_path.display());
+}
+
 fn create(configuration: &Configuration, name: String) -> anyhow::Result<()> {
     let existing_pack = configuration.pack_set.for_pack(&name);
     if existing_pack.is_ok() {

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -61,6 +61,12 @@ enum Command {
     #[clap(about = "Just saying hi")]
     Greet,
 
+    #[clap(about = "Set up packs in this project")]
+    Init {
+        #[arg(long, default_value = ".")]
+        path: PathBuf,
+    },
+
     #[clap(about = "Create a new pack")]
     Create { name: String },
 
@@ -186,6 +192,14 @@ pub fn run() -> anyhow::Result<()> {
 
     install_logger(args.debug);
 
+    match args.command {
+        Command::Init { ref path } => {
+            packs::init(&path);
+            ()
+        }
+        _ => {}
+    }
+
     let mut configuration = packs::configuration::get(&absolute_root)?;
 
     if args.print_files {
@@ -225,6 +239,10 @@ pub fn run() -> anyhow::Result<()> {
     match args.command {
         Command::Greet => {
             packs::greet();
+            Ok(())
+        }
+        Command::Init { path: _ } => {
+            println!("Successfully initalized packs in this directory!");
             Ok(())
         }
         Command::ListPacks => {

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -62,10 +62,7 @@ enum Command {
     Greet,
 
     #[clap(about = "Set up packs in this project")]
-    Init {
-        #[arg(long, default_value = ".")]
-        path: PathBuf,
-    },
+    Init,
 
     #[clap(about = "Create a new pack")]
     Create { name: String },
@@ -193,9 +190,8 @@ pub fn run() -> anyhow::Result<()> {
     install_logger(args.debug);
 
     match args.command {
-        Command::Init { ref path } => {
-            packs::init(&path);
-            ()
+        Command::Init => {
+            packs::init(&absolute_root)?
         }
         _ => {}
     }
@@ -241,8 +237,8 @@ pub fn run() -> anyhow::Result<()> {
             packs::greet();
             Ok(())
         }
-        Command::Init { path: _ } => {
-            println!("Successfully initalized packs in this directory!");
+        Command::Init => {
+            println!("Successfully initialized packs in this directory!");
             Ok(())
         }
         Command::ListPacks => {

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -193,6 +193,10 @@ pub fn run() -> anyhow::Result<()> {
 
     install_logger(args.debug);
 
+    // The `init` command is run in directories which have no configuration yet, however, below we
+    // attempt to load configuration before the CLI commands are processed. To avoid this catch-22
+    // we process `init` here, before configuration load. In future consider restructuring so that
+    // command matching is not dependent on configuration files being available.
     if let Command::Init { use_packwerk } = args.command {
         packs::init(&absolute_root, use_packwerk)?
     }

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -62,7 +62,11 @@ enum Command {
     Greet,
 
     #[clap(about = "Set up packs in this project")]
-    Init,
+    Init {
+        /// Generate packwerk compatible packwerk.yml instead of packs.yml
+        #[arg(long)]
+        use_packwerk: bool,
+    },
 
     #[clap(about = "Create a new pack")]
     Create { name: String },
@@ -189,11 +193,8 @@ pub fn run() -> anyhow::Result<()> {
 
     install_logger(args.debug);
 
-    match args.command {
-        Command::Init => {
-            packs::init(&absolute_root)?
-        }
-        _ => {}
+    if let Command::Init { use_packwerk } = args.command {
+        packs::init(&absolute_root, use_packwerk)?
     }
 
     let mut configuration = packs::configuration::get(&absolute_root)?;
@@ -237,8 +238,11 @@ pub fn run() -> anyhow::Result<()> {
             packs::greet();
             Ok(())
         }
-        Command::Init => {
-            println!("Successfully initialized packs in this directory!");
+        Command::Init { use_packwerk } => {
+            println!(
+                "Successfully initialized packs{} in this directory!",
+                if use_packwerk { "/packwerk" } else { "" }
+            );
             Ok(())
         }
         Command::ListPacks => {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -32,8 +32,8 @@ pub fn delete_foobar() {
 }
 
 #[allow(dead_code)]
-pub fn create_new_app() {
-    let directory = PathBuf::from("tests/fixtures/new_app");
+pub fn create_new_app(dir_name: &str) {
+    let directory = PathBuf::from(format!("tests/fixtures/{}", dir_name));
     if let Err(err) = fs::create_dir_all(directory) {
         eprintln!(
             "Failed to create tests/fixtures/new_app during test setup: {}",
@@ -41,9 +41,10 @@ pub fn create_new_app() {
         );
     }
 }
+
 #[allow(dead_code)]
-pub fn delete_new_app() {
-    let directory = PathBuf::from("tests/fixtures/new_app");
+pub fn delete_new_app(dir_name: &str) {
+    let directory = PathBuf::from(format!("tests/fixtures/{}", dir_name));
     if let Err(err) = fs::remove_dir_all(directory) {
         eprintln!(
             "Failed to remove tests/fixtures/new_app during test teardown: {}",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -31,6 +31,27 @@ pub fn delete_foobar() {
     }
 }
 
+#[allow(dead_code)]
+pub fn create_new_app() {
+    let directory = PathBuf::from("tests/fixtures/new_app");
+    if let Err(err) = fs::create_dir_all(directory) {
+        eprintln!(
+            "Failed to create tests/fixtures/new_app during test setup: {}",
+            err
+        );
+    }
+}
+#[allow(dead_code)]
+pub fn delete_new_app() {
+    let directory = PathBuf::from("tests/fixtures/new_app");
+    if let Err(err) = fs::remove_dir_all(directory) {
+        eprintln!(
+            "Failed to remove tests/fixtures/new_app during test teardown: {}",
+            err
+        );
+    }
+}
+
 // In case we want our tests to call `update` or otherwise mutate the file system
 #[allow(dead_code)]
 pub fn set_up_fixtures() {

--- a/tests/init_test.rs
+++ b/tests/init_test.rs
@@ -1,0 +1,32 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::{error::Error, process::Command, fs};
+
+mod common;
+
+#[test]
+fn init_pack() -> Result<(), Box<dyn Error>> {
+    common::create_new_app();
+
+    Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg("tests/fixtures/new_app")
+        .arg("init")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created "))
+        .stdout(predicate::str::contains("tests/fixtures/new_app/packwerk.yml'"))
+        .stdout(predicate::str::contains("tests/fixtures/new_app/package.yml'"));
+
+    let expected = "This file represents the root package of the application\n";
+    let actual = fs::read_to_string(
+        "tests/fixtures/new_app/package.yml",
+    ).unwrap_or_else(|_| panic!("Could not read file tests/fixtures/new_app/package.yml"));
+    assert!(actual.contains(expected));
+
+
+    common::teardown();
+    common::delete_new_app();
+
+    Ok(())
+}


### PR DESCRIPTION
As discussed in #144 an init command might be nice. 

This is probably the first time I have ever written any Rust so I just tried copying things I saw in the existing implementation and did some work arounds to compile errors using ChatGPT. 

Ideally someone with some experience could help turn this into a proper solution that is more idiomatic etc!

I added the config file creation at a point before the configuration load happens to avoid it blowing up but Im sure there is a better solution here. 

Anyway thought it might be a starting point!