### PR TITLE
Consistent "Result" types

### DIFF
--- a/src/main-alt.rs
+++ b/src/main-alt.rs
@@ -1,5 +1,5 @@
 use packs::packs::cli;
 
-pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+pub fn main() -> anyhow::Result<()> {
     cli::run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use packs::packs::cli;
 
-pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+pub fn main() -> anyhow::Result<()> {
     cli::run()
 }

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -38,7 +38,6 @@ pub(crate) use package_todo::PackageTodo;
 // External imports
 use serde::Deserialize;
 use serde::Serialize;
-use std::error::Error;
 use std::path::PathBuf;
 
 pub fn greet() {
@@ -91,13 +90,11 @@ See https://github.com/rubyatscale/packs#readme for more info!",
 pub fn check(
     configuration: &Configuration,
     files: Vec<String>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     checker::check_all(configuration, files)
 }
 
-pub fn update(
-    configuration: &Configuration,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn update(configuration: &Configuration) -> anyhow::Result<()> {
     checker::update(configuration)
 }
 
@@ -105,7 +102,7 @@ pub fn add_dependency(
     configuration: &Configuration,
     from: String,
     to: String,
-) -> Result<(), Box<dyn Error>> {
+) -> anyhow::Result<()> {
     let pack_set = &configuration.pack_set;
 
     let from_pack = pack_set
@@ -146,9 +143,7 @@ pub fn add_dependency(
     Ok(())
 }
 
-pub fn list_included_files(
-    configuration: Configuration,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn list_included_files(configuration: Configuration) -> anyhow::Result<()> {
     configuration
         .included_files
         .iter()
@@ -156,9 +151,7 @@ pub fn list_included_files(
     Ok(())
 }
 
-pub fn validate(
-    configuration: &Configuration,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn validate(configuration: &Configuration) -> anyhow::Result<()> {
     checker::validate_all(configuration)
 }
 
@@ -170,7 +163,7 @@ pub fn configuration(project_root: PathBuf) -> Configuration {
 pub fn check_unnecessary_dependencies(
     configuration: &Configuration,
     auto_correct: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     if auto_correct {
         checker::remove_unnecessary_dependencies(configuration)
     } else {

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -14,6 +14,7 @@ use crate::packs::package_todo;
 use crate::packs::Configuration;
 use crate::packs::PackSet;
 
+use anyhow::bail;
 // External imports
 use rayon::prelude::IntoParallelIterator;
 use rayon::prelude::IntoParallelRefIterator;
@@ -218,7 +219,7 @@ impl<'a> CheckAllBuilder<'a> {
 pub(crate) fn check_all(
     configuration: &Configuration,
     files: Vec<String>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     let checkers = get_checkers(configuration);
 
     debug!("Intersecting input files with configuration included files");
@@ -271,7 +272,7 @@ pub(crate) fn check_all(
     }
 
     if errors_present {
-        Err("Packwerk check failed".into())
+        bail!("Packwerk check failed")
     } else {
         println!("No violations detected!");
         Ok(())
@@ -300,7 +301,7 @@ fn validate(configuration: &Configuration) -> Vec<String> {
 
 pub(crate) fn validate_all(
     configuration: &Configuration,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     let validation_errors = validate(configuration);
     if !validation_errors.is_empty() {
         println!("{} validation error(s) detected:", validation_errors.len());
@@ -308,16 +309,14 @@ pub(crate) fn validate_all(
             println!("{}\n", validation_error);
         }
 
-        Err("Packwerk validate failed".into())
+        bail!("Packwerk validate failed")
     } else {
         println!("Packwerk validate succeeded!");
         Ok(())
     }
 }
 
-pub(crate) fn update(
-    configuration: &Configuration,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn update(configuration: &Configuration) -> anyhow::Result<()> {
     let checkers = get_checkers(configuration);
 
     let violations = get_all_violations(
@@ -333,7 +332,7 @@ pub(crate) fn update(
 
 pub(crate) fn remove_unnecessary_dependencies(
     configuration: &Configuration,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     let unnecessary_dependencies = get_unnecessary_dependencies(configuration);
     for (pack, dependency_names) in unnecessary_dependencies.iter() {
         remove_reference_to_dependency(pack, dependency_names);
@@ -343,7 +342,7 @@ pub(crate) fn remove_unnecessary_dependencies(
 
 pub(crate) fn check_unnecessary_dependencies(
     configuration: &Configuration,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> anyhow::Result<()> {
     let unnecessary_dependencies = get_unnecessary_dependencies(configuration);
     if unnecessary_dependencies.is_empty() {
         Ok(())
@@ -356,7 +355,7 @@ pub(crate) fn check_unnecessary_dependencies(
                 )
             }
         }
-        Err("List unnecessary dependencies failed".into())
+        bail!("List unnecessary dependencies failed")
     }
 }
 

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -145,12 +145,14 @@ struct ExposeMonkeyPatchesArgs {
 }
 
 impl Args {
-    fn absolute_project_root(&self) -> Result<PathBuf, std::io::Error> {
-        self.project_root.canonicalize()
+    fn absolute_project_root(&self) -> anyhow::Result<PathBuf> {
+        self.project_root
+            .canonicalize()
+            .map_err(anyhow::Error::from)
     }
 }
 
-pub fn run() -> Result<(), Box<dyn std::error::Error>> {
+pub fn run() -> anyhow::Result<()> {
     let args = Args::parse();
     let absolute_root = args
         .absolute_project_root()

--- a/tests/add_constant_dependencies.rs
+++ b/tests/add_constant_dependencies.rs
@@ -2,7 +2,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use pretty_assertions::assert_eq;
 use serial_test::serial;
-use std::{collections::HashSet, error::Error, path::PathBuf};
+use std::{collections::HashSet, path::PathBuf};
 
 mod common;
 


### PR DESCRIPTION
### Why?
This PR aims to standardize the error handling across the codebase by adopting the [anyhow](https://docs.rs/anyhow/latest/anyhow/) crate, which was previously introduced due to its ergonomic advantages. The goal is to consistently utilize the anyhow Result type throughout the project.

A [good summary](https://antoinerr.github.io/blog-website/2023/01/28/rust-anyhow.html) of anyhow's advantages

### What?
Modified the entrypoint result types in `packs` to use [anyhow](https://docs.rs/anyhow/latest/anyhow/).
