### PR TITLE
Collect check messages and print results 

### DIFF
--- a/src/packs.rs
+++ b/src/packs.rs
@@ -32,10 +32,12 @@ pub(crate) use self::parsing::ruby::experimental::get_experimental_constant_reso
 pub(crate) use self::parsing::ruby::zeitwerk::get_zeitwerk_constant_resolver;
 pub(crate) use self::parsing::ParsedDefinition;
 pub(crate) use self::parsing::UnresolvedReference;
+use anyhow::bail;
 pub(crate) use configuration::Configuration;
 pub(crate) use package_todo::PackageTodo;
 
 // External imports
+use anyhow::Context;
 use serde::Deserialize;
 use serde::Serialize;
 use std::path::PathBuf;
@@ -91,7 +93,13 @@ pub fn check(
     configuration: &Configuration,
     files: Vec<String>,
 ) -> anyhow::Result<()> {
-    checker::check_all(configuration, files)
+    let result = checker::check_all(configuration, files)
+        .context("Failed to check files")?;
+    println!("{}", result);
+    if result.has_violations() {
+        bail!("Violations found!")
+    }
+    Ok(())
 }
 
 pub fn update(configuration: &Configuration) -> anyhow::Result<()> {


### PR DESCRIPTION
### Why?
To support different output formats, It would be better to collect errors and decide how they should be rendered at a higher level.

Examples:
1. when using `packs` in CI, we might want packs to respond in a JSON format
2. we might want to surface a "check" API which returns the actual violations instead of printing them 

### What?
Printing "check" results in packs.rb rather than inline.

### Notes
This PR builds off of https://github.com/alexevanczuk/packs/pull/152
