### PR TITLE
refactored some "panics" to instead return errors

### DIFF
--- a/src/packs/caching/cache.rs
+++ b/src/packs/caching/cache.rs
@@ -5,7 +5,7 @@ use crate::packs::ProcessedFile;
 use super::{CacheResult, EmptyCacheEntry};
 
 pub trait Cache {
-    fn get(&self, path: &Path) -> CacheResult;
+    fn get(&self, path: &Path) -> anyhow::Result<CacheResult>;
 
     fn write(
         &self,

--- a/src/packs/caching/mod.rs
+++ b/src/packs/caching/mod.rs
@@ -19,19 +19,22 @@ pub struct EmptyCacheEntry {
 }
 
 impl EmptyCacheEntry {
-    pub fn new(cache_directory: &Path, filepath: &Path) -> EmptyCacheEntry {
+    pub fn new(
+        cache_directory: &Path,
+        filepath: &Path,
+    ) -> anyhow::Result<EmptyCacheEntry> {
         let file_digest = md5::compute(filepath.to_str().unwrap());
         let file_name_digest = format!("{:x}", file_digest);
         let cache_file_path = cache_directory.join(&file_name_digest);
 
-        let file_contents_digest = file_content_digest(filepath);
+        let file_contents_digest = file_content_digest(filepath)?;
 
-        EmptyCacheEntry {
+        Ok(EmptyCacheEntry {
             filepath: filepath.to_owned(),
             file_contents_digest,
             cache_file_path,
             file_name_digest,
-        }
+        })
     }
 }
 

--- a/src/packs/caching/noop_cache.rs
+++ b/src/packs/caching/noop_cache.rs
@@ -7,9 +7,9 @@ use super::{cache::Cache, CacheResult, EmptyCacheEntry};
 pub struct NoopCache {}
 
 impl Cache for NoopCache {
-    fn get(&self, _path: &Path) -> CacheResult {
+    fn get(&self, _path: &Path) -> anyhow::Result<CacheResult> {
         // Return nothing!
-        CacheResult::Miss(EmptyCacheEntry::default())
+        Ok(CacheResult::Miss(EmptyCacheEntry::default()))
     }
 
     fn write(

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -225,17 +225,13 @@ pub fn run() -> anyhow::Result<()> {
         }
         Command::ListDefinitions(args) => {
             let ambiguous = args.ambiguous;
-            packs::list_definitions(&configuration, ambiguous);
-            Ok(())
+            packs::list_definitions(&configuration, ambiguous)
         }
-        Command::ExposeMonkeyPatches(args) => {
-            packs::expose_monkey_patches(
-                &configuration,
-                &args.rubydir,
-                &args.gemdir,
-            );
-            Ok(())
-        }
+        Command::ExposeMonkeyPatches(args) => packs::expose_monkey_patches(
+            &configuration,
+            &args.rubydir,
+            &args.gemdir,
+        ),
         Command::LintPackageYmlFiles => {
             packs::lint_package_yml_files(&configuration);
             Ok(())

--- a/src/packs/constant_dependencies.rs
+++ b/src/packs/constant_dependencies.rs
@@ -14,7 +14,7 @@ pub fn update_dependencies_for_constant(
     constant_name: &str,
 ) -> anyhow::Result<usize> {
     let all_references =
-        get_all_references(configuration, &configuration.included_files);
+        get_all_references(configuration, &configuration.included_files)?;
     if let Some((defining_pack_name, reference_pack_names_set)) =
         find_defining_and_referencing_packs(&all_references, constant_name)
     {

--- a/src/packs/file_utils.rs
+++ b/src/packs/file_utils.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use crate::packs::Configuration;
+use anyhow::Context;
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use regex::Regex;
 
@@ -114,18 +115,18 @@ pub(crate) fn convert_erb_to_ruby_without_sourcemaps(
     extracted_contents.join("\n")
 }
 
-pub(crate) fn file_content_digest(file: &Path) -> String {
+pub(crate) fn file_content_digest(file: &Path) -> anyhow::Result<String> {
     let mut file_content = Vec::new();
 
     // Read the file content
     let mut file_handle = fs::File::open(file)
-        .unwrap_or_else(|_| panic!("Failed to open file {:?}", file));
+        .context(format!("Failed to open file {:?}", file))?;
     file_handle
         .read_to_end(&mut file_content)
-        .expect("Failed to read file");
+        .context(format!("Failed to read file {:?}", file))?;
 
     // Compute the MD5 digest
-    format!("{:x}", md5::compute(&file_content))
+    Ok(format!("{:x}", md5::compute(&file_content)))
 }
 
 pub fn file_read_contents(

--- a/src/packs/monkey_patch_detection.rs
+++ b/src/packs/monkey_patch_detection.rs
@@ -1,5 +1,6 @@
 use std::{cmp::Ordering, collections::HashMap, path::PathBuf};
 
+use anyhow::bail;
 use tracing::debug;
 
 use crate::packs::{
@@ -14,10 +15,10 @@ pub fn expose_monkey_patches(
     configuration: &Configuration,
     rubydir: &PathBuf,
     gemdir: &PathBuf,
-) -> String {
+) -> anyhow::Result<String> {
     let mut lines_to_print: Vec<String> = vec![];
     if !configuration.experimental_parser {
-        panic!("This command is only supported with the experimental parser! `packs help` for more info.")
+        bail!("This command is only supported with the experimental parser! `packs help` for more info.")
     }
 
     debug!("Globbing out rubydir and gemdir");
@@ -31,7 +32,7 @@ pub fn expose_monkey_patches(
         &included_files,
         configuration.get_cache(),
         configuration,
-    );
+    )?;
 
     let constant_resolver = get_experimental_constant_resolver(
         &configuration.absolute_root,
@@ -187,7 +188,7 @@ pub fn expose_monkey_patches(
 
     lines_to_print.push("</details>".to_owned());
 
-    lines_to_print.join("\n")
+    Ok(lines_to_print.join("\n"))
 }
 
 fn get_redefinition_line_to_print(
@@ -265,6 +266,7 @@ These monkey patches redefine behavior in a pack within your app (as determined 
             ),
         );
 
-        assert_eq!(expected_message, actual_message);
+        assert!(actual_message.is_ok());
+        assert_eq!(expected_message, actual_message.unwrap());
     }
 }

--- a/src/packs/reference_extractor.rs
+++ b/src/packs/reference_extractor.rs
@@ -13,7 +13,7 @@ use super::{checker::reference::Reference, Configuration};
 pub(crate) fn get_all_references(
     configuration: &Configuration,
     absolute_paths: &HashSet<PathBuf>,
-) -> Vec<Reference> {
+) -> anyhow::Result<Vec<Reference>> {
     let cache = configuration.get_cache();
 
     debug!("Getting unresolved references (using cache if possible)");
@@ -26,7 +26,7 @@ pub(crate) fn get_all_references(
             &configuration.included_files,
             cache,
             configuration,
-        );
+        )?;
 
         let constant_resolver = get_experimental_constant_resolver(
             &configuration.absolute_root,
@@ -44,7 +44,7 @@ pub(crate) fn get_all_references(
         (constant_resolver, processed_files_to_check)
     } else {
         let processed_files: Vec<ProcessedFile> =
-            process_files_with_cache(absolute_paths, cache, configuration);
+            process_files_with_cache(absolute_paths, cache, configuration)?;
 
         // The zeitwerk constant resolver doesn't look at processed files to get definitions
         let constant_resolver = get_zeitwerk_constant_resolver(
@@ -78,5 +78,5 @@ pub(crate) fn get_all_references(
 
     debug!("Finished turning unresolved references into fully qualified references");
 
-    references
+    Ok(references)
 }


### PR DESCRIPTION
### What?
Instead of "panic!", return anyhow::Result

### Why?
This will give us better control to print friendly error messages and/or provide APIs

### Notes
I tried to keep this PR small, but changing a result type kicks off a game of whack-a-mole.

