### PR TITLE
Configuration returns anyhow::Result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,14 @@ mod test_util {
 
     pub fn get_zeitwerk_constant_resolver_for_fixture(
         fixture_name: &str,
-    ) -> Box<dyn ConstantResolver> {
+    ) -> anyhow::Result<Box<dyn ConstantResolver>> {
         let absolute_root = get_absolute_root(fixture_name);
-        let configuration = configuration::get(&absolute_root);
+        let configuration = configuration::get(&absolute_root)?;
 
-        get_zeitwerk_constant_resolver(
+        Ok(get_zeitwerk_constant_resolver(
             &configuration.pack_set,
             &configuration.constant_resolver_configuration(),
-        )
+        ))
     }
 
     // Note that instead, we could derive the `Default` trait on `Pack`
@@ -84,6 +84,7 @@ mod test_util {
                 RawConfiguration::default(),
                 walk_directory_result,
             )
+            .unwrap() // TODO: potentially convert `default` to `new` and return a Result
         }
     }
 }

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -139,7 +139,7 @@ pub fn add_dependency(
     // (which takes ownership over the previous one).
     // For now, we simply refetch the entire configuration for simplicity,
     // since we don't mind the slowdown for this CLI command.
-    let new_configuration = configuration::get(&configuration.absolute_root);
+    let new_configuration = configuration::get(&configuration.absolute_root)?;
     let validation_result = packs::validate(&new_configuration);
     if validation_result.is_err() {
         println!("Added `{}` as a dependency to `{}`!", to, from);
@@ -163,8 +163,8 @@ pub fn validate(configuration: &Configuration) -> anyhow::Result<()> {
     checker::validate_all(configuration)
 }
 
-pub fn configuration(project_root: PathBuf) -> Configuration {
-    let absolute_root = project_root.canonicalize().unwrap();
+pub fn configuration(project_root: PathBuf) -> anyhow::Result<Configuration> {
+    let absolute_root = project_root.canonicalize()?;
     configuration::get(&absolute_root)
 }
 
@@ -318,7 +318,8 @@ mod tests {
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
-        );
+        )
+        .unwrap();
         let absolute_file_path = configuration
             .absolute_root
             .join("packs/foo/app/services/foo.rb")

--- a/src/packs/caching/per_file_cache.rs
+++ b/src/packs/caching/per_file_cache.rs
@@ -105,9 +105,10 @@ mod tests {
     use super::*;
 
     fn teardown() {
-        packs::delete_cache(configuration::get(&PathBuf::from(
-            "tests/fixtures/simple_app",
-        )));
+        packs::delete_cache(
+            configuration::get(&PathBuf::from("tests/fixtures/simple_app"))
+                .unwrap(),
+        );
     }
 
     #[test]

--- a/src/packs/checker/architecture.rs
+++ b/src/packs/checker/architecture.rs
@@ -258,7 +258,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
         assert_eq!(None, checker.check(&reference, &configuration))
@@ -312,7 +313,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
 
@@ -380,7 +382,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
 
@@ -444,7 +447,8 @@ mod tests {
                     to_pack.clone(),
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             layers: Layers {
                 layers: test_case.layers,
             },
@@ -510,7 +514,8 @@ mod tests {
             .canonicalize()
             .expect("Could not canonicalize path")
             .as_path(),
-        );
+        )
+        .unwrap();
         let checker = Checker {
             layers: Layers {
                 layers: vec![

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -210,7 +210,8 @@ mod tests {
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
-        );
+        )
+        .unwrap();
         let reference = Reference {
             constant_name: String::from("::Foo"),
             defining_pack_name: Some(String::from("packs/foo")),
@@ -234,7 +235,8 @@ mod tests {
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
-        );
+        )
+        .unwrap();
         let reference = build_foo_reference_bar_reference();
 
         let expected_violation = Violation {
@@ -261,7 +263,8 @@ mod tests {
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
-        );
+        )
+        .unwrap();
         let reference = build_foo_reference_bar_reference();
 
         assert_eq!(checker.check(&reference, &configuration), None)
@@ -290,7 +293,8 @@ mod tests {
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
-        );
+        )
+        .unwrap();
 
         let error = checker.validate(&configuration);
         let expected_message = vec![String::from("Package cannot list itself as a dependency: packs/baz/package.yml"),
@@ -312,7 +316,8 @@ packs/foo, packs/bar",
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
-        );
+        )
+        .unwrap();
 
         let error = checker.validate(&configuration);
         assert_eq!(error, None);
@@ -329,7 +334,8 @@ packs/foo, packs/bar",
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
-        );
+        )
+        .unwrap();
 
         checker.validate(&configuration);
     }

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -180,7 +180,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
 
@@ -239,7 +240,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
 
@@ -290,7 +292,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
 
@@ -349,7 +352,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
 
@@ -400,7 +404,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
 
@@ -462,7 +467,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
 
@@ -527,7 +533,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
 
@@ -581,7 +588,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
 
@@ -631,7 +639,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
         assert_eq!(None, checker.check(&reference, &configuration))
@@ -681,7 +690,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
         assert_eq!(None, checker.check(&reference, &configuration))

--- a/src/packs/checker/visibility.rs
+++ b/src/packs/checker/visibility.rs
@@ -141,7 +141,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
 
@@ -199,7 +200,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
         assert_eq!(
@@ -252,7 +254,8 @@ mod tests {
                     referencing_pack,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         };
         assert_eq!(None, checker.check(&reference, &configuration))

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -160,7 +160,7 @@ pub fn run() -> anyhow::Result<()> {
 
     install_logger(args.debug);
 
-    let mut configuration = packs::configuration::get(&absolute_root);
+    let mut configuration = packs::configuration::get(&absolute_root)?;
 
     if args.print_files {
         configuration.print_files = true;

--- a/src/packs/constant_dependencies.rs
+++ b/src/packs/constant_dependencies.rs
@@ -207,7 +207,8 @@ mod tests {
                     referencing_pack_baz,
                 ]),
                 HashMap::new(),
-            ),
+            )
+            .unwrap(),
             ..Configuration::default()
         }
     }

--- a/src/packs/monkey_patch_detection.rs
+++ b/src/packs/monkey_patch_detection.rs
@@ -254,7 +254,8 @@ These monkey patches redefine behavior in a pack within your app (as determined 
 
         let mut configuration = configuration::get(&PathBuf::from(
             "tests/fixtures/app_with_monkey_patches",
-        ));
+        ))
+        .unwrap();
         configuration.experimental_parser = true;
         let actual_message = expose_monkey_patches(
             &configuration,

--- a/src/packs/pack_set.rs
+++ b/src/packs/pack_set.rs
@@ -33,7 +33,7 @@ impl PackSet {
     pub fn build(
         packs: HashSet<Pack>,
         owning_package_yml_for_file: HashMap<PathBuf, PathBuf>,
-    ) -> PackSet {
+    ) -> anyhow::Result<PackSet> {
         let packs: Vec<Pack> = packs
             .into_iter()
             .sorted_by(|packa, packb| {
@@ -65,15 +65,15 @@ impl PackSet {
         let indexed_packs = indexed_packs_by_name;
 
         if indexed_packs.get(".").is_none() {
-            panic!("No root pack found. First double check a root pack exists (a package.yml file in the application root). Secondly, double check your packwerk.yml `package_paths` includes the root pack by using command packs list-packs.");
+            bail!("No root pack found. First double check a root pack exists (a package.yml file in the application root). Secondly, double check your packwerk.yml `package_paths` includes the root pack by using command packs list-packs.");
         }
 
-        PackSet {
+        Ok(PackSet {
             indexed_packs,
             packs,
             all_violations,
             owning_pack_name_for_file,
-        }
+        })
     }
 
     pub fn for_file(&self, absolute_file_path: &Path) -> Option<&Pack> {
@@ -155,7 +155,7 @@ mod tests {
         let mut packs = HashSet::new();
         packs.insert(foo_pack);
         packs.insert(root_pack);
-        PackSet::build(packs, HashMap::new())
+        PackSet::build(packs, HashMap::new()).unwrap()
     }
 
     #[test]

--- a/src/packs/parsing/ruby/zeitwerk/mod.rs
+++ b/src/packs/parsing/ruby/zeitwerk/mod.rs
@@ -230,9 +230,10 @@ mod tests {
     use crate::packs::configuration;
 
     fn teardown() {
-        packs::delete_cache(configuration::get(&PathBuf::from(
-            "tests/fixtures/simple_app",
-        )));
+        packs::delete_cache(
+            configuration::get(&PathBuf::from("tests/fixtures/simple_app"))
+                .unwrap(),
+        );
     }
 
     use crate::test_util::{
@@ -250,6 +251,7 @@ mod tests {
                     .join("packs/foo/app/services/foo.rb")
             }],
             get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP)
+                .unwrap()
                 .resolve(&String::from("Foo"), &[])
                 .unwrap()
         );
@@ -266,6 +268,7 @@ mod tests {
                     .join("app/company_data/widget.rb")
             }],
             get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP)
+                .unwrap()
                 .resolve(&String::from("Widget"), &["Company"])
                 .unwrap()
         );
@@ -276,7 +279,8 @@ mod tests {
     #[test]
     fn nested_reference_to_unnested_constant() {
         let absolute_root = get_absolute_root(SIMPLE_APP);
-        let resolver = get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP);
+        let resolver =
+            get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP).unwrap();
 
         assert_eq!(
             vec![ConstantDefinition {
@@ -295,7 +299,8 @@ mod tests {
     #[test]
     fn nested_reference_to_nested_constant() {
         let absolute_root = get_absolute_root(SIMPLE_APP);
-        let resolver = get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP);
+        let resolver =
+            get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP).unwrap();
         assert_eq!(
             vec![ConstantDefinition {
                 fully_qualified_name: "::Foo::Bar".to_string(),
@@ -311,7 +316,8 @@ mod tests {
     #[test]
     fn nested_reference_to_global_constant() {
         let absolute_root = get_absolute_root(SIMPLE_APP);
-        let resolver = get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP);
+        let resolver =
+            get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP).unwrap();
 
         assert_eq!(
             vec![ConstantDefinition {
@@ -328,7 +334,8 @@ mod tests {
     #[test]
     fn nested_reference_to_constant_defined_within_another_file() {
         let absolute_root = get_absolute_root(SIMPLE_APP);
-        let resolver = get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP);
+        let resolver =
+            get_zeitwerk_constant_resolver_for_fixture(SIMPLE_APP).unwrap();
         assert_eq!(
             vec![ConstantDefinition {
                 fully_qualified_name: "::Bar::BAR".to_string(),
@@ -345,7 +352,7 @@ mod tests {
     fn inflected_constant() {
         let app = "tests/fixtures/app_with_inflections";
         let absolute_root = get_absolute_root(app);
-        let resolver = get_zeitwerk_constant_resolver_for_fixture(app);
+        let resolver = get_zeitwerk_constant_resolver_for_fixture(app).unwrap();
 
         assert_eq!(
             vec![ConstantDefinition {
@@ -378,7 +385,7 @@ mod tests {
             .canonicalize()
             .expect("Could not canonicalize path");
 
-        let configuration = configuration::get(absolute_root);
+        let configuration = configuration::get(absolute_root).unwrap();
 
         let constant_resolver = get_zeitwerk_constant_resolver(
             &configuration.pack_set,

--- a/tests/add_constant_dependencies.rs
+++ b/tests/add_constant_dependencies.rs
@@ -22,7 +22,8 @@ fn test_add_constant_dependencies() -> anyhow::Result<()> {
 
     let config = packs::packs::configuration(PathBuf::from(
         "tests/fixtures/app_with_missing_dependencies",
-    ));
+    ))
+    .unwrap();
 
     let pack = config.pack_set.for_pack("packs/foo").unwrap();
     assert_eq!(pack.dependencies.len(), 0);

--- a/tests/add_dependency_test.rs
+++ b/tests/add_dependency_test.rs
@@ -23,7 +23,8 @@ fn test_add_dependency() -> Result<(), Box<dyn Error>> {
 
     let config = packs::packs::configuration(PathBuf::from(
         "tests/fixtures/app_with_missing_dependency",
-    ));
+    ))
+    .unwrap();
 
     let pack = config.pack_set.for_pack("packs/baz").unwrap();
 
@@ -62,7 +63,8 @@ fn test_add_dependency_creating_cycle() -> Result<(), Box<dyn Error>> {
 
     let config = packs::packs::configuration(PathBuf::from(
         "tests/fixtures/app_with_missing_dependency",
-    ));
+    ))
+    .unwrap();
 
     let pack = config.pack_set.for_pack("packs/bar").unwrap();
 
@@ -92,7 +94,8 @@ fn test_add_dependency_unnecessarily() -> Result<(), Box<dyn Error>> {
 
     let config = packs::packs::configuration(PathBuf::from(
         "tests/fixtures/app_with_missing_dependency",
-    ));
+    ))
+    .unwrap();
 
     let pack = config.pack_set.for_pack("packs/foo").unwrap();
 


### PR DESCRIPTION
With this change, `Configuration` functions return `anyhow::Result`s instead of panicking.

In a subsequent PR, we might convert Configuration::default(), to `new` so it also can return a `Result` instead of panicking.