### PR TITLE
check returns anyhow::Result

### DIFF
--- a/src/packs/checker/folder_visibility.rs
+++ b/src/packs/checker/folder_visibility.rs
@@ -11,16 +11,16 @@ impl CheckerInterface for Checker {
         &self,
         reference: &Reference,
         configuration: &Configuration,
-    ) -> Option<Violation> {
+    ) -> anyhow::Result<Option<Violation>> {
         let pack_set = &configuration.pack_set;
         let referencing_pack = &reference.referencing_pack(pack_set);
         let relative_defining_file = &reference.relative_defining_file;
         if relative_defining_file.is_none() {
-            return None;
+            return Ok(None);
         }
-        let defining_pack = &reference.defining_pack(pack_set);
+        let defining_pack = &reference.defining_pack(pack_set)?;
         if defining_pack.is_none() {
-            return None;
+            return Ok(None);
         }
         let defining_pack = defining_pack.unwrap();
         if !folder_visible(referencing_pack, defining_pack).unwrap() {
@@ -40,12 +40,12 @@ impl CheckerInterface for Checker {
                 referencing_pack_name: referencing_pack.name.clone(),
                 defining_pack_name: defining_pack.name.clone(),
             };
-            Some(Violation {
+            Ok(Some(Violation {
                 message,
                 identifier,
-            })
+            }))
         } else {
-            None
+            Ok(None)
         }
     }
 

--- a/src/packs/checker/reference.rs
+++ b/src/packs/checker/reference.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::bail;
+use anyhow::{bail, Context};
 
 use crate::packs::{
     constant_resolver::ConstantResolver, pack::Pack,
@@ -18,11 +18,19 @@ pub struct Reference {
 }
 
 impl Reference {
-    pub fn defining_pack<'a>(&self, pack_set: &'a PackSet) -> Option<&'a Pack> {
+    pub fn defining_pack<'a>(
+        &self,
+        pack_set: &'a PackSet,
+    ) -> anyhow::Result<Option<&'a Pack>> {
         if let Some(name) = &self.defining_pack_name {
-            Some(pack_set.for_pack(name).unwrap_or_else(|_| panic!("Reference#defining_pack_name is {}, but that pack is not found in pack set.", &name)))
+            Ok(Some(pack_set
+                .for_pack(name)
+                .context(format!(
+                    "Reference#defining_pack_name is {}, but that pack is not found in pack set.",
+                    &name
+                ))?))
         } else {
-            None
+            Ok(None)
         }
     }
 


### PR DESCRIPTION
Rather than panic, `check` not returns an `anyhow::Result`