### PR TITLE
Setting ViolationIdentifier `strict` in all checkers

### DIFF
--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -34,6 +34,7 @@ use super::reference_extractor::get_all_references;
 #[derive(PartialEq, Clone, Eq, Hash, Debug)]
 pub struct ViolationIdentifier {
     pub violation_type: String,
+    pub strict: bool,
     pub file: String,
     pub constant_name: String,
     pub referencing_pack_name: String,

--- a/src/packs/checker/common_test.rs
+++ b/src/packs/checker/common_test.rs
@@ -28,10 +28,12 @@ pub mod tests {
     pub fn build_expected_violation(
         message: String,
         violation_type: String,
+        strict: bool,
     ) -> Violation {
         build_expected_violation_with_constant(
             message,
             violation_type,
+            strict,
             String::from("::Bar"),
         )
     }
@@ -39,14 +41,16 @@ pub mod tests {
     pub fn build_expected_violation_with_constant(
         message: String,
         violation_type: String,
+        strict: bool,
         constant_name: String,
     ) -> Violation {
         Violation {
             message,
             identifier: ViolationIdentifier {
                 violation_type,
+                strict,
                 file: String::from("packs/foo/app/services/foo.rb"),
-                constant_name: constant_name,
+                constant_name,
                 referencing_pack_name: String::from("packs/foo"),
                 defining_pack_name: String::from("packs/bar"),
             },

--- a/src/packs/pack.rs
+++ b/src/packs/pack.rs
@@ -151,6 +151,7 @@ impl Pack {
                     for file in &violation_group.files {
                         let identifier = ViolationIdentifier {
                             violation_type: violation_type.clone(),
+                            strict: false,
                             file: file.clone(),
                             constant_name: constant_name.clone(),
                             referencing_pack_name: self.name.clone(),

--- a/src/packs/pack.rs
+++ b/src/packs/pack.rs
@@ -624,4 +624,39 @@ owner: Foobar
             vec![root.join("app/company_data"), root.join("app/services")];
         assert_eq!(expected, actual)
     }
+
+    #[test]
+    fn test_all_recorded_violations() -> anyhow::Result<()> {
+        let root = test_util::get_absolute_root(
+            "tests/fixtures/contains_package_todo",
+        );
+        let pack = Pack::from_path(
+            root.join("packs/foo/package.yml").as_path(),
+            root.as_path(),
+        )?;
+
+        let mut actual = pack.all_violations();
+        actual.sort_by(|a, b| a.file.cmp(&b.file));
+
+        let expected = vec![
+            ViolationIdentifier {
+                violation_type: "dependency".to_string(),
+                strict: false,
+                file: "packs/foo/app/services/foo.rb".to_string(),
+                constant_name: "::Bar".to_string(),
+                referencing_pack_name: "packs/foo".to_string(),
+                defining_pack_name: "packs/bar".to_string(),
+            },
+            ViolationIdentifier {
+                violation_type: "dependency".to_string(),
+                strict: false,
+                file: "packs/foo/app/services/other_foo.rb".to_string(),
+                constant_name: "::Bar".to_string(),
+                referencing_pack_name: "packs/foo".to_string(),
+                defining_pack_name: "packs/bar".to_string(),
+            },
+        ];
+        assert_eq!(expected, actual);
+        Ok(())
+    }
 }


### PR DESCRIPTION
Background
---
https://github.com/alexevanczuk/packs/issues/166

We need to know if a violation is `strict` in order to ignore the violation when writing out todos.

Changes
---
- [x] added `strict` to `ViolationIdentifier`
- [x] set `strict` in all of the Checker.check functions

Upcoming PR
---
- do not write out todo if violation is strict
- use the new `strict` field to determine [strict mode violations](https://github.com/perryqh/packs/blob/ph/strict-violation-id/src/packs/checker.rs#L252)