### PR TITLE
Not writing strict violations to todos

### DIFF
--- a/src/packs/checker/common_test.rs
+++ b/src/packs/checker/common_test.rs
@@ -28,10 +28,12 @@ pub mod tests {
     pub fn build_expected_violation(
         message: String,
         violation_type: String,
+        strict: bool,
     ) -> Violation {
         build_expected_violation_with_constant(
             message,
             violation_type,
+            strict,
             String::from("::Bar"),
         )
     }
@@ -39,14 +41,16 @@ pub mod tests {
     pub fn build_expected_violation_with_constant(
         message: String,
         violation_type: String,
+        strict: bool,
         constant_name: String,
     ) -> Violation {
         Violation {
             message,
             identifier: ViolationIdentifier {
                 violation_type,
+                strict,
                 file: String::from("packs/foo/app/services/foo.rb"),
-                constant_name: constant_name,
+                constant_name,
                 referencing_pack_name: String::from("packs/foo"),
                 defining_pack_name: String::from("packs/bar"),
             },

--- a/src/packs/pack.rs
+++ b/src/packs/pack.rs
@@ -151,6 +151,7 @@ impl Pack {
                     for file in &violation_group.files {
                         let identifier = ViolationIdentifier {
                             violation_type: violation_type.clone(),
+                            strict: false,
                             file: file.clone(),
                             constant_name: constant_name.clone(),
                             referencing_pack_name: self.name.clone(),
@@ -622,5 +623,40 @@ owner: Foobar
         let expected =
             vec![root.join("app/company_data"), root.join("app/services")];
         assert_eq!(expected, actual)
+    }
+
+    #[test]
+    fn test_all_recorded_violations() -> anyhow::Result<()> {
+        let root = test_util::get_absolute_root(
+            "tests/fixtures/contains_package_todo",
+        );
+        let pack = Pack::from_path(
+            root.join("packs/foo/package.yml").as_path(),
+            root.as_path(),
+        )?;
+
+        let mut actual = pack.all_violations();
+        actual.sort_by(|a, b| a.file.cmp(&b.file));
+
+        let expected = vec![
+            ViolationIdentifier {
+                violation_type: "dependency".to_string(),
+                strict: false,
+                file: "packs/foo/app/services/foo.rb".to_string(),
+                constant_name: "::Bar".to_string(),
+                referencing_pack_name: "packs/foo".to_string(),
+                defining_pack_name: "packs/bar".to_string(),
+            },
+            ViolationIdentifier {
+                violation_type: "dependency".to_string(),
+                strict: false,
+                file: "packs/foo/app/services/other_foo.rb".to_string(),
+                constant_name: "::Bar".to_string(),
+                referencing_pack_name: "packs/foo".to_string(),
+                defining_pack_name: "packs/bar".to_string(),
+            },
+        ];
+        assert_eq!(expected, actual);
+        Ok(())
     }
 }

--- a/src/packs/package_todo.rs
+++ b/src/packs/package_todo.rs
@@ -141,6 +141,9 @@ pub fn write_violations_to_disk(
     let mut violations_by_responsible_pack: HashMap<String, Vec<Violation>> =
         HashMap::new();
     for violation in violations {
+        if violation.identifier.strict {
+            continue;
+        }
         let referencing_pack_name =
             violation.identifier.referencing_pack_name.to_owned();
         violations_by_responsible_pack

--- a/tests/fixtures/contains_strict_violations/packs/bar/app/services/bar.rb
+++ b/tests/fixtures/contains_strict_violations/packs/bar/app/services/bar.rb
@@ -1,0 +1,2 @@
+module Bar
+end

--- a/tests/fixtures/contains_strict_violations/packs/bar/package.yml
+++ b/tests/fixtures/contains_strict_violations/packs/bar/package.yml
@@ -1,0 +1,1 @@
+enforce_privacy: strict

--- a/tests/fixtures/contains_strict_violations/packs/foo/app/services/foo.rb
+++ b/tests/fixtures/contains_strict_violations/packs/foo/app/services/foo.rb
@@ -1,0 +1,5 @@
+module Foo
+  def calls_bar_with_stated_dependency
+    Bar
+  end
+end

--- a/tests/fixtures/contains_strict_violations/packs/foo/package.yml
+++ b/tests/fixtures/contains_strict_violations/packs/foo/package.yml
@@ -1,0 +1,3 @@
+enforce_dependencies: true
+dependencies:
+  - packs/bar

--- a/tests/fixtures/contains_strict_violations/packwerk.yml
+++ b/tests/fixtures/contains_strict_violations/packwerk.yml
@@ -1,0 +1,23 @@
+# See: Setting up the configuration file
+# https://github.com/Shopify/packwerk/blob/main/USAGE.md#setting-up-the-configuration-file
+
+# List of patterns for folder paths to include
+# include:
+# - "**/*.{rb,rake,erb}"
+
+# List of patterns for folder paths to exclude
+# exclude:
+# - "{bin,node_modules,script,tmp,vendor}/**/*"
+
+# Patterns to find package configuration files
+# package_paths: "**/"
+
+# List of custom associations, if any
+# custom_associations:
+# - "cache_belongs_to"
+
+# Whether or not you want the cache enabled (disabled by default)
+cache: false
+
+# Where you want the cache to be stored (default below)
+# cache_directory: 'tmp/cache/packwerk'

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -202,6 +202,10 @@ fn test_update_with_strict_violations() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout(predicate::str::contains(
+            "packs/foo cannot have privacy violations on packs/bar because strict mode is enabled for privacy violations in the enforcing pack's package.yml file",
+        ))
+        .stdout(predicate::str::contains("1 strict mode violation(s) detected."))
+        .stdout(predicate::str::contains(
             "Successfully updated package_todo.yml files!",
         ));
 

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -187,3 +187,27 @@ packs/bar:
 
     Ok(())
 }
+
+#[test]
+fn test_update_with_strict_violations() -> anyhow::Result<()> {
+    let path = Path::new(
+        "tests/fixtures/contains_strict_violations/packs/foo/package_todo.yml",
+    );
+    let _ignore = std::fs::remove_file(path);
+
+    Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg("tests/fixtures/contains_strict_violations")
+        .arg("update")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Successfully updated package_todo.yml files!",
+        ));
+
+    assert!(
+        !path.exists(),
+        "todo should not be created for strict violations"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Background
---
Strict violations always cause `pks check` failures. There's no need to write out strict violations to "todo" files.

Changes
---
- [x] not writing strict violations to todos
- [x] report strict violations when running `pks update`. `pks update` will still exit with `0` 