### PR TITLE
Removing unused "strict-mode" code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.88"
+version = "0.1.89"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -13,11 +13,9 @@ use crate::packs::pack::write_pack_to_disk;
 use crate::packs::pack::Pack;
 use crate::packs::package_todo;
 use crate::packs::Configuration;
-use crate::packs::PackSet;
 
 use anyhow::bail;
 // External imports
-use anyhow::Context;
 use rayon::prelude::IntoParallelIterator;
 use rayon::prelude::IntoParallelRefIterator;
 use rayon::prelude::ParallelIterator;
@@ -40,25 +38,6 @@ pub struct ViolationIdentifier {
     pub referencing_pack_name: String,
     pub defining_pack_name: String,
 }
-
-pub fn get_defining_pack<'a>(
-    violation: &ViolationIdentifier,
-    packset: &'a PackSet,
-) -> anyhow::Result<&'a Pack> {
-    packset.for_pack(&violation.defining_pack_name)
-    .context(format!("ViolationIdentifier#defining_pack is {}, but that pack cannot be found in the packset.", 
-    &violation.defining_pack_name))
-}
-
-pub fn get_referencing_pack<'a>(
-    violation: &ViolationIdentifier,
-    packset: &'a PackSet,
-) -> anyhow::Result<&'a Pack> {
-    packset.for_pack(&violation.referencing_pack_name)
-    .context(format!("ViolationIdentifier#referencing_pack is {}, but that pack cannot be found in the packset.",
-&violation.referencing_pack_name))
-}
-
 #[derive(PartialEq, Clone, Eq, Hash, Debug)]
 pub struct Violation {
     message: String,
@@ -71,12 +50,6 @@ pub(crate) trait CheckerInterface {
         reference: &Reference,
         configuration: &Configuration,
     ) -> anyhow::Result<Option<Violation>>;
-
-    fn is_strict_mode_violation(
-        &self,
-        offense: &ViolationIdentifier,
-        configuration: &Configuration,
-    ) -> anyhow::Result<bool>;
 
     fn violation_type(&self) -> String;
 }

--- a/src/packs/checker/architecture.rs
+++ b/src/packs/checker/architecture.rs
@@ -1,7 +1,4 @@
-use super::{
-    get_referencing_pack, CheckerInterface, ValidatorInterface,
-    ViolationIdentifier,
-};
+use super::{CheckerInterface, ValidatorInterface, ViolationIdentifier};
 use crate::packs::checker::Reference;
 use crate::packs::pack::Pack;
 use crate::packs::{Configuration, Violation};
@@ -185,17 +182,6 @@ impl CheckerInterface for Checker {
             }
             _ => Ok(None),
         }
-    }
-
-    fn is_strict_mode_violation(
-        &self,
-        violation: &ViolationIdentifier,
-        configuration: &Configuration,
-    ) -> anyhow::Result<bool> {
-        let referencing_pack =
-            get_referencing_pack(violation, &configuration.pack_set)?;
-
-        Ok(referencing_pack.enforce_architecture().is_strict())
     }
 
     fn violation_type(&self) -> String {

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
 
-use super::{
-    get_referencing_pack, CheckerInterface, ValidatorInterface,
-    ViolationIdentifier,
-};
+use super::{CheckerInterface, ValidatorInterface, ViolationIdentifier};
 use crate::packs::checker::Reference;
 use crate::packs::pack::Pack;
 use crate::packs::{Configuration, Violation};
@@ -179,17 +176,6 @@ impl CheckerInterface for Checker {
         }
 
         Ok(None)
-    }
-
-    fn is_strict_mode_violation(
-        &self,
-        violation: &ViolationIdentifier,
-        configuration: &Configuration,
-    ) -> anyhow::Result<bool> {
-        let referencing_pack =
-            get_referencing_pack(violation, &configuration.pack_set)?;
-
-        Ok(referencing_pack.enforce_dependencies().is_strict())
     }
 
     fn violation_type(&self) -> String {

--- a/src/packs/checker/folder_visibility.rs
+++ b/src/packs/checker/folder_visibility.rs
@@ -1,4 +1,4 @@
-use super::{get_referencing_pack, CheckerInterface, ViolationIdentifier};
+use super::{CheckerInterface, ViolationIdentifier};
 use crate::packs::checker::reference::Reference;
 use crate::packs::pack::Pack;
 use crate::packs::{Configuration, Violation};
@@ -48,17 +48,6 @@ impl CheckerInterface for Checker {
         } else {
             Ok(None)
         }
-    }
-
-    fn is_strict_mode_violation(
-        &self,
-        violation: &ViolationIdentifier,
-        configuration: &Configuration,
-    ) -> anyhow::Result<bool> {
-        let referencing_pack =
-            get_referencing_pack(violation, &configuration.pack_set)?;
-
-        Ok(referencing_pack.enforce_folder_visibility().is_strict())
     }
 
     fn violation_type(&self) -> String {

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -1,4 +1,4 @@
-use super::{get_defining_pack, CheckerInterface, ViolationIdentifier};
+use super::{CheckerInterface, ViolationIdentifier};
 use crate::packs::checker::Reference;
 use crate::packs::{Configuration, Violation};
 
@@ -113,17 +113,6 @@ impl CheckerInterface for Checker {
             message,
             identifier,
         }))
-    }
-
-    fn is_strict_mode_violation(
-        &self,
-        violation: &ViolationIdentifier,
-        configuration: &Configuration,
-    ) -> anyhow::Result<bool> {
-        let defining_pack =
-            get_defining_pack(violation, &configuration.pack_set)?;
-
-        Ok(defining_pack.enforce_privacy().is_strict())
     }
 
     fn violation_type(&self) -> String {

--- a/src/packs/checker/visibility.rs
+++ b/src/packs/checker/visibility.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use super::{get_defining_pack, CheckerInterface, ViolationIdentifier};
+use super::{CheckerInterface, ViolationIdentifier};
 use crate::packs::checker::Reference;
 use crate::packs::{Configuration, Violation};
 
@@ -75,17 +75,6 @@ impl CheckerInterface for Checker {
             message,
             identifier,
         }))
-    }
-
-    fn is_strict_mode_violation(
-        &self,
-        violation: &ViolationIdentifier,
-        configuration: &Configuration,
-    ) -> anyhow::Result<bool> {
-        let defining_pack =
-            get_defining_pack(violation, &configuration.pack_set)?;
-
-        Ok(defining_pack.enforce_visibility().is_strict())
     }
 
     fn violation_type(&self) -> String {


### PR DESCRIPTION
With the recent changes to when strict-mode is determined, the `is_strict_mode_violation` function became obsolete.