### PR TITLE
Providing a better check_unnecessary_dependencies error message

### DIFF
--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -347,7 +347,18 @@ pub(crate) fn check_unnecessary_dependencies(
                 )
             }
         }
-        bail!("List unnecessary dependencies failed")
+        let found_message = if unnecessary_dependencies.len() == 1 {
+            "Found 1 unnecessary dependency".to_string()
+        } else {
+            format!(
+                "Found {} unnecessary dependencies",
+                unnecessary_dependencies.len()
+            )
+        };
+        bail!(
+            "{}. Run command with `--auto-correct` to remove them.",
+            found_message,
+        );
     }
 }
 

--- a/tests/check_unnecessary_dependencies.rs
+++ b/tests/check_unnecessary_dependencies.rs
@@ -17,6 +17,9 @@ fn test_check_unnecessary_dependencies() -> Result<(), Box<dyn Error>> {
         ))
         .stdout(predicate::str::contains(
             "packs/foo depends on packs/bar but does not use it",
+        ))
+        .stderr(predicate::str::contains(
+           "Error: Found 3 unnecessary dependencies. Run command with `--auto-correct` to remove them.",
         ));
     Ok(())
 }


### PR DESCRIPTION
Background
---
When the `check-unnecessary-dependencies` command finds unnecessary dependencies, it prints `List unnecessary dependencies failed`. This message can be confusing in that it might be unintentionally communicating that the command itself failed rather than unnecessary dependencies were found.

Change
---
Updates the message to clearly communicate that unnecessary dependencies were found.