### PR TITLE
A better error message for corrupted todo files

### DIFF
--- a/src/packs/pack.rs
+++ b/src/packs/pack.rs
@@ -201,7 +201,7 @@ impl Pack {
                 .context("Could not read the package_todo.yml file")?;
             serde_yaml::from_str(&package_todo_contents).with_context(|| {
                 format!(
-                    "Failed to deserialize the package_todo.yml file at {}",
+                    "Failed to deserialize the package_todo.yml file at {}. Try deleting the file and running the `update` command to regenerate it.",
                     absolute_path_to_package_todo.display()
                 )
             })?

--- a/tests/corrupt_todo_test.rs
+++ b/tests/corrupt_todo_test.rs
@@ -1,0 +1,19 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+mod common;
+
+#[test]
+fn test_check_with_corrupt_todo() -> anyhow::Result<()> {
+    Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg("tests/fixtures/contains_corrupt_todo")
+        .arg("--debug")
+        .arg("check")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to deserialize the package_todo.yml"))
+        .stderr(predicate::str::contains("Try deleting the file and running the `update` command to regenerate it"));
+
+    common::teardown();
+    Ok(())
+}

--- a/tests/fixtures/contains_corrupt_todo/packs/bar/app/services/bar.rb
+++ b/tests/fixtures/contains_corrupt_todo/packs/bar/app/services/bar.rb
@@ -1,0 +1,2 @@
+module Bar
+end

--- a/tests/fixtures/contains_corrupt_todo/packs/bar/package.yml
+++ b/tests/fixtures/contains_corrupt_todo/packs/bar/package.yml
@@ -1,0 +1,1 @@
+enforce_privacy: true

--- a/tests/fixtures/contains_corrupt_todo/packs/bar/package_todo.yml
+++ b/tests/fixtures/contains_corrupt_todo/packs/bar/package_todo.yml
@@ -1,0 +1,16 @@
+# This file contains a list of dependencies that are not part of the long term plan for the
+# 'packs/foo' package.
+# We should generally work to reduce this list over time.
+#
+# You can regenerate this file using the following command:
+#
+# bin/packwerk update-todo
+---
+packs/foo:
+  "::Foo":
+    violations:
+    - dependency
+    - privacy
+    files:
+    - packs/bar/app/services/bar.rb
+

--- a/tests/fixtures/contains_corrupt_todo/packs/foo/app/services/foo.rb
+++ b/tests/fixtures/contains_corrupt_todo/packs/foo/app/services/foo.rb
@@ -1,0 +1,5 @@
+module Foo
+  def calls_bar_with_stated_dependency
+    Bar
+  end
+end

--- a/tests/fixtures/contains_corrupt_todo/packs/foo/package.yml
+++ b/tests/fixtures/contains_corrupt_todo/packs/foo/package.yml
@@ -1,0 +1,3 @@
+enforce_dependencies: true
+dependencies:
+  - packs/bar

--- a/tests/fixtures/contains_corrupt_todo/packs/foo/package_todo.yml
+++ b/tests/fixtures/contains_corrupt_todo/packs/foo/package_todo.yml
@@ -1,0 +1,11 @@
+# This file contains a list of dependencies that are not part of the long term plan for the
+# 'packs/foo' package.
+# We should generally work to reduce this list over time.
+#
+# You can regenerate this file using the following command:
+#
+# bin/packwerk update-todo
+---
+packs/bar:
+  "::Bar"
+    - packs/foo/app/services/foo.rb

--- a/tests/fixtures/contains_corrupt_todo/packwerk.yml
+++ b/tests/fixtures/contains_corrupt_todo/packwerk.yml
@@ -1,0 +1,23 @@
+# See: Setting up the configuration file
+# https://github.com/Shopify/packwerk/blob/main/USAGE.md#setting-up-the-configuration-file
+
+# List of patterns for folder paths to include
+# include:
+# - "**/*.{rb,rake,erb}"
+
+# List of patterns for folder paths to exclude
+# exclude:
+# - "{bin,node_modules,script,tmp,vendor}/**/*"
+
+# Patterns to find package configuration files
+# package_paths: "**/"
+
+# List of custom associations, if any
+# custom_associations:
+# - "cache_belongs_to"
+
+# Whether or not you want the cache enabled (disabled by default)
+cache: false
+
+# Where you want the cache to be stored (default below)
+# cache_directory: 'tmp/cache/packwerk'


### PR DESCRIPTION
Context
---
A developer had a corrupt todo file and didn't know how to fix it. The corrupted todo file was likely caused by accidental "manual" edits to it.

Change
---
Updating the error message to include a solution for fixing their corrupt todo files.


