### PR TITLE
Returning invalid layer error instead of panicking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.90"
+version = "0.1.91"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tracing = "0.1.37" # logging
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] } # logging
 glob = "0.3.1" # globbing
 globset = "0.4.10" # globbing
-lib-ruby-parser = "4.0.5" # ruby parser
+lib-ruby-parser = "4.0.6" # ruby parser
 md5 = "0.7.0" # md5 hashing to take and compare md5 digests of file contents to ensure cache validity
 line-col = "0.2.1" # for creating source maps of violations
 ruby_inflector = '0.0.8' # for inflecting strings, e.g. turning `has_many :companies` into `Company`

--- a/src/packs/checker/architecture.rs
+++ b/src/packs/checker/architecture.rs
@@ -146,8 +146,7 @@ impl CheckerInterface for Checker {
             (Some(referencing_layer), Some(defining_layer)) => {
                 if self
                     .layers
-                    .can_depend_on(referencing_layer, defining_layer)
-                    .unwrap()
+                    .can_depend_on(referencing_layer, defining_layer)?
                 {
                     return Ok(None);
                 }


### PR DESCRIPTION
If a `package.yml` specified an invalid 'layer', we want to handle it gracefully instead of panicking.