### PR TITLE
Bump version to get CI green again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.92"
+version = "0.1.93"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"


### PR DESCRIPTION
There's a weird issue right now where is a PR that bumped the version caused a failure to upload the binary, subsequent commits will fail. We think CI will go green again bumping the version since the release should be created. We could probably make CI/CD more robust but this should be fine for now.