### PR TITLE
Updating layer validations

### DIFF
--- a/tests/fixtures/app_with_architecture_violations_in_yml/packs/bar/package.yml
+++ b/tests/fixtures/app_with_architecture_violations_in_yml/packs/bar/package.yml
@@ -1,3 +1,3 @@
 enforce_privacy: true
-enforce_architecture: true
+enforce_architecture: false 
 layer: admin

--- a/tests/fixtures/app_with_architecture_violations_in_yml/packs/baz/package.yml
+++ b/tests/fixtures/app_with_architecture_violations_in_yml/packs/baz/package.yml
@@ -1,5 +1,4 @@
 enforce_privacy: true
 enforce_architecture: true
-layer: technical_services
 dependencies:
   - packs/bar

--- a/tests/fixtures/app_with_architecture_violations_in_yml/packs/foo/package.yml
+++ b/tests/fixtures/app_with_architecture_violations_in_yml/packs/foo/package.yml
@@ -1,6 +1,6 @@
 enforce_dependencies: true
 enforce_privacy: true
 enforce_architecture: true
-layer: product
+layer: not_a_layer
 dependencies:
 - packs/bar

--- a/tests/validate_test.rs
+++ b/tests/validate_test.rs
@@ -35,12 +35,10 @@ packs/foo, packs/bar",
 #[test]
 fn test_validate_architecture() -> Result<(), Box<dyn Error>> {
     let expected_message_1 = String::from(
-        "
-Invalid 'dependencies' in 'packs/baz/package.yml'. 'packs/baz/package.yml' has a layer type of 'technical_services,' which cannot rely on 'packs/bar,' which has a layer type of 'admin.' `architecture_layers` can be found in packwerk.yml",
+        "\'layer\' must be specified in \'packs/baz/package.yml\' because `enforce_architecture` is true or strict.",
     );
     let expected_message_2 = String::from(
-        "
-Invalid 'dependencies' in 'packs/foo/package.yml'. 'packs/foo/package.yml' has a layer type of 'product,' which cannot rely on 'packs/bar,' which has a layer type of 'admin.' `architecture_layers` can be found in packwerk.yml",
+        "Invalid \'layer\' option in \'packs/foo/package.yml\'. `layer` must be one of the layers defined in `packwerk.yml`"
     );
 
     Command::cargo_bin("packs")


### PR DESCRIPTION
### Layer Validation rules
- if a layer is specified in a `package.yml`, it must be one of the layers defined in `packwerk.yml`
- if `enforce_architecture` is `true` or `strict`, a layer must be specified
- a packages' dependencies should not be used in layer validations. `check` will find layer violations