### PR TITLE
Use cross to build linux artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,9 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -42,18 +34,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
       - name: Run cargo test with backtrace
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -- --nocapture
+        run: cargo test -- --nocapture
         env:
           RUST_BACKTRACE: 1
   lints:
@@ -63,25 +45,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings
 
   release:
     runs-on: macos-latest
@@ -100,12 +68,6 @@ jobs:
           # TLDR – By default this action fetches no history.
           # We need a bit of history to be able to check if we've recently updated the version in Cargo.toml
           fetch-depth: 2
-      - name: Update local toolchain
-        run: |
-          rustup update
-          rustup component add clippy
-          rustup target add aarch64-apple-darwin
-          rustup target add x86_64-apple-darwin
       - name: Toolchain info
         run: |
           cargo --version --verbose
@@ -161,10 +123,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update local toolchain
         run: |
-          rustup update
-          rustup target add x86_64-unknown-linux-gnu
+          cargo install cross
       - name: Build
-        run: cargo build --release --target x86_64-unknown-linux-gnu  
+        run: cross build --release --target x86_64-unknown-linux-gnu
       - name: Upload linux binary
         run: |
           tar -czf target/packs-linux-unknown.tar.gz -C target/x86_64-unknown-linux-gnu/release pks packs
@@ -173,4 +134,3 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ needs.release.outputs.new_version }}
 
-    

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.77.2"
+components = ["clippy", "rustfmt"]
+targets = ["x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
By using cross, the build of the artifact will have a more stable ABI because the docker image has a [well defined version of libraries][1] that are defined, meaning that updates to "ubuntu-latest" won't impact the compatible version of the built binaries.

This change defines the "toolchain" for rust, meaning that new versions of rust won't automatically be picked up (unless changed to stable).

This also removes the `action-rs` uses, because they are deprecated and the github actions install rustup by default

  [1]: https://github.com/cross-rs/cross?tab=readme-ov-file#supported-targets