### PR TITLE
Fix stale check when deleted

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.1.96"
+version = "0.1.97"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -132,13 +132,30 @@ fn test_check_with_stale_violations() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn test_check_with_stale_violations_when_file_no_longer_exists(
+) -> Result<(), Box<dyn Error>> {
+    Command::cargo_bin("packs")
+        .unwrap()
+        .arg("--project-root")
+        .arg("tests/fixtures/contains_stale_violations_no_file")
+        .arg("check")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "There were stale violations found, please run `packs update`",
+        ));
+
+    common::teardown();
+    Ok(())
+}
+
+#[test]
 fn test_check_without_stale_violations() -> Result<(), Box<dyn Error>> {
     Command::cargo_bin("packs")
         .unwrap()
         .arg("--project-root")
         .arg("tests/fixtures/contains_package_todo")
         .arg("check")
-        .arg("packs/foo/app/services/foo.rb")
         .assert()
         .success()
         .stdout(

--- a/tests/fixtures/contains_stale_violations_no_file/packs/bar/app/services/bar.rb
+++ b/tests/fixtures/contains_stale_violations_no_file/packs/bar/app/services/bar.rb
@@ -1,0 +1,5 @@
+module Bar
+    def bar_you
+        Foo.foo_you
+    end
+end

--- a/tests/fixtures/contains_stale_violations_no_file/packs/bar/package.yml
+++ b/tests/fixtures/contains_stale_violations_no_file/packs/bar/package.yml
@@ -1,0 +1,1 @@
+enforce_privacy: true

--- a/tests/fixtures/contains_stale_violations_no_file/packs/bar/package_todo.yml
+++ b/tests/fixtures/contains_stale_violations_no_file/packs/bar/package_todo.yml
@@ -1,0 +1,16 @@
+# This file contains a list of dependencies that are not part of the long term plan for the
+# 'packs/foo' package.
+# We should generally work to reduce this list over time.
+#
+# You can regenerate this file using the following command:
+#
+# bin/packwerk update-todo
+---
+packs/foo:
+  "::Foo":
+    violations:
+    - privacy
+    files:
+    - packs/bar/app/services/bar.rb
+    - packs/bar/app/services/file_was_deleted.rb
+

--- a/tests/fixtures/contains_stale_violations_no_file/packs/foo/app/services/foo.rb
+++ b/tests/fixtures/contains_stale_violations_no_file/packs/foo/app/services/foo.rb
@@ -1,0 +1,5 @@
+module Foo
+  def self.foo_you
+    'foo you'
+  end
+end

--- a/tests/fixtures/contains_stale_violations_no_file/packs/foo/package.yml
+++ b/tests/fixtures/contains_stale_violations_no_file/packs/foo/package.yml
@@ -1,0 +1,2 @@
+enforce_privacy: true
+

--- a/tests/fixtures/contains_stale_violations_no_file/packwerk.yml
+++ b/tests/fixtures/contains_stale_violations_no_file/packwerk.yml
@@ -1,0 +1,23 @@
+# See: Setting up the configuration file
+# https://github.com/Shopify/packwerk/blob/main/USAGE.md#setting-up-the-configuration-file
+
+# List of patterns for folder paths to include
+# include:
+# - "**/*.{rb,rake,erb}"
+
+# List of patterns for folder paths to exclude
+# exclude:
+# - "{bin,node_modules,script,tmp,vendor}/**/*"
+
+# Patterns to find package configuration files
+# package_paths: "**/"
+
+# List of custom associations, if any
+# custom_associations:
+# - "cache_belongs_to"
+
+# Whether or not you want the cache enabled (disabled by default)
+cache: false
+
+# Where you want the cache to be stored (default below)
+# cache_directory: 'tmp/cache/packwerk'


### PR DESCRIPTION
## Background
We noticed that `packs check` doesn't report a violation as "stale" if the file no longer exists.

Example:
```yml
"::Item":
    violations:
    - dependency
    files:
    - packs/product_services/items/path/to/file_no_longer_exists.rb
```
If `file_no_longer_exists.rb` is deleted, `pks check` does not report it as stale.

## Fix
Consider a violation stale if the file does not exist