### PR TITLE
adding aarch64-linux-unknown release binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,12 +124,16 @@ jobs:
       - name: Update local toolchain
         run: |
           cargo install cross
-      - name: Build
-        run: cross build --release --target x86_64-unknown-linux-gnu
-      - name: Upload linux binary
+      - name: Build linux binaries
         run: |
-          tar -czf target/packs-linux-unknown.tar.gz -C target/x86_64-unknown-linux-gnu/release pks packs
-          gh release upload v$NEW_VERSION target/packs-linux-unknown.tar.gz
+          cross build --release --target x86_64-unknown-linux-gnu
+          cross build --release --target aarch64-unknown-linux-gnu
+      - name: Upload linux binaries
+        run: |
+          tar -czf target/x86_64-linux-unknown.tar.gz -C target/x86_64-unknown-linux-gnu/release pks packs
+          tar -czf target/aarch64-linux-unknown.tar.gz -C target/aarch64-unknown-linux-gnu/release pks packs
+          gh release upload v$NEW_VERSION target/x86_64-linux-unknown.tar.gz
+          gh release upload v$NEW_VERSION target/aarch64-linux-unknown.tar.gz 
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ needs.release.outputs.new_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,10 +130,10 @@ jobs:
           cross build --release --target aarch64-unknown-linux-gnu
       - name: Upload linux binaries
         run: |
-          tar -czf target/x86_64-linux-unknown.tar.gz -C target/x86_64-unknown-linux-gnu/release pks packs
-          tar -czf target/aarch64-linux-unknown.tar.gz -C target/aarch64-unknown-linux-gnu/release pks packs
-          gh release upload v$NEW_VERSION target/x86_64-linux-unknown.tar.gz
-          gh release upload v$NEW_VERSION target/aarch64-linux-unknown.tar.gz 
+          tar -czf target/x86_64-unknown-linux-gnu.tar.gz -C target/x86_64-unknown-linux-gnu/release pks packs
+          tar -czf target/aarch64-unknown-linux-gnu.tar.gz -C target/aarch64-unknown-linux-gnu/release pks packs
+          gh release upload v$NEW_VERSION target/x86_64-unknown-linux-gnu.tar.gz
+          gh release upload v$NEW_VERSION target/aarch64-unknown-linux-gnu.tar.gz 
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ needs.release.outputs.new_version }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"


### PR DESCRIPTION
Releasing an aarch64 linux binary


[Test](https://github.com/perryqh/packs-ci/releases/tag/v0.2.3)