### PR TITLE
Violations report in csv or json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ regex = "1.7.3"
 serde = { version = "~1", features = ["derive"] } # de(serialization)
 serde_yaml = "0.9.19" # de(serialization)
 serde_json = "1.0.96" # de(serialization)
+csv = "1.3.0" # de(serialization)
 serde_magnus = "0.7.0" # permits a ruby gem to interface with this library
 tracing = "0.1.37" # logging
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] } # logging

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -13,6 +13,7 @@ pub(crate) mod monkey_patch_detection;
 pub(crate) mod pack;
 pub(crate) mod parsing;
 pub(crate) mod raw_configuration;
+pub(crate) mod reports;
 pub(crate) mod walk_directory;
 
 mod constant_dependencies;

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -20,6 +20,7 @@ use rayon::prelude::IntoParallelIterator;
 use rayon::prelude::IntoParallelRefIterator;
 use rayon::prelude::ParallelIterator;
 use reference::Reference;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Display;
@@ -29,7 +30,7 @@ use tracing::debug;
 
 use super::reference_extractor::get_all_references;
 
-#[derive(PartialEq, Clone, Eq, Hash, Debug)]
+#[derive(PartialEq, Clone, Eq, Hash, Debug, Serialize)]
 pub struct ViolationIdentifier {
     pub violation_type: String,
     pub strict: bool,

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -3,10 +3,13 @@ use crate::packs;
 use crate::packs::file_utils::get_absolute_path;
 use clap::{Parser, Subcommand};
 use clap_derive::Args;
-use std::path::PathBuf;
+use std::{io, path::PathBuf};
 use tracing::debug;
 
-use super::logger::install_logger;
+use super::{
+    logger::install_logger,
+    reports::{recorded_violations, ReportFormat},
+};
 
 /// A CLI to interact with packs
 #[derive(Parser, Debug)]
@@ -128,6 +131,12 @@ enum Command {
         about = "List the constants that packs sees and where it sees them (for debugging purposes)"
     )]
     ListDefinitions(ListDefinitionsArgs),
+
+    #[clap(about = "Report all Todo violations (for reporting purposes)")]
+    ReportTodoViolations {
+        #[arg(short, long)]
+        format: ReportFormat,
+    },
 }
 
 #[derive(Debug, Args)]
@@ -193,6 +202,9 @@ pub fn run() -> anyhow::Result<()> {
         }
         Command::ListPackDependencies { pack } => {
             packs::list_dependencies(&configuration, pack)
+        }
+        Command::ReportTodoViolations { format } => {
+            recorded_violations(&configuration, format, &mut io::stdout())
         }
         Command::AddDependency { from, to } => {
             packs::add_dependency(&configuration, from, to)

--- a/src/packs/reports.rs
+++ b/src/packs/reports.rs
@@ -1,0 +1,79 @@
+use std::io;
+
+use serde_json::json;
+
+use super::Configuration;
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub(crate) enum ReportFormat {
+    Csv,
+    Json,
+}
+
+pub(crate) fn recorded_violations(
+    configuration: &Configuration,
+    report_format: ReportFormat,
+    writer: &mut impl io::Write,
+) -> anyhow::Result<()> {
+    let recorded_violations = &configuration.pack_set.all_violations;
+
+    match report_format {
+        ReportFormat::Csv => {
+            let mut csv_writer = csv::Writer::from_writer(writer);
+            for violation in recorded_violations {
+                csv_writer.serialize(violation)?;
+            }
+            csv_writer.flush()?;
+        }
+        ReportFormat::Json => {
+            serde_json::to_writer(
+                writer,
+                &json!({
+                    "violations": recorded_violations,
+                }),
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::packs::configuration;
+
+    use super::*;
+
+    #[test]
+    fn test_recorded_violations_json() -> anyhow::Result<()> {
+        let configuration = configuration::get(
+            PathBuf::from("tests/fixtures/contains_stale_violations")
+                .canonicalize()
+                .expect("Could not canonicalize path")
+                .as_path(),
+        )?;
+        let mut writer = Vec::new();
+        recorded_violations(&configuration, ReportFormat::Json, &mut writer)?;
+        let parsed_json: serde_json::Value = serde_json::from_slice(&writer)?;
+        assert_eq!(parsed_json["violations"].as_array().unwrap().len(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn test_recorded_violations_csv() -> anyhow::Result<()> {
+        let configuration = configuration::get(
+            PathBuf::from("tests/fixtures/contains_stale_violations")
+                .canonicalize()
+                .expect("Could not canonicalize path")
+                .as_path(),
+        )?;
+        let mut writer = Vec::new();
+        recorded_violations(&configuration, ReportFormat::Csv, &mut writer)?;
+        let csv_string = String::from_utf8(writer)?;
+        assert_eq!(csv_string.lines().count(), 5);
+        assert_eq!(csv_string.lines().nth(0).unwrap(), "violation_type,strict,file,constant_name,referencing_pack_name,defining_pack_name");
+        Ok(())
+    }
+}


### PR DESCRIPTION
`pks report-todo-violations --format csv > zp-violations.csv` will generate a csv with all recorded violations.

`json` is also supported