### PR TITLE
Make file path cyan in output like packwerk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ line-col = "0.2.1" # for creating source maps of violations
 ruby_inflector = '0.0.8' # for inflecting strings, e.g. turning `has_many :companies` into `Company`
 petgraph = "0.6.3" # for running graph algorithms (e.g. does the dependency graph contain a cycle?)
 fnmatch-regex2 = "0.3.0"
+strip-ansi-escapes = "0.2.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.10" # testing CLI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs/checker.rs
+++ b/src/packs/checker.rs
@@ -4,6 +4,7 @@ pub(crate) mod layer;
 
 mod common_test;
 mod folder_visibility;
+mod output_helper;
 mod privacy;
 pub(crate) mod reference;
 mod visibility;

--- a/src/packs/checker/common_test.rs
+++ b/src/packs/checker/common_test.rs
@@ -136,7 +136,22 @@ pub mod tests {
             });
 
         let result = checker.check(&reference, &configuration)?;
-        assert_eq!(result, test_checker.expected_violation);
+
+        let stripped_result = match result {
+            Some(violation) => {
+                let stripped_message =
+                    strip_ansi_escapes::strip(violation.message);
+
+                Some(Violation {
+                    message: String::from_utf8_lossy(&stripped_message)
+                        .to_string(),
+                    ..violation
+                })
+            }
+            None => None,
+        };
+
+        assert_eq!(stripped_result, test_checker.expected_violation);
 
         Ok(())
     }

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -165,7 +165,7 @@ impl CheckerInterface for Checker {
         // END: Original packwerk message
 
         let message = format!(
-                "{}:{}:{}\nDependency violation: `{}` belongs to `{}`, but `{}` does not specify a dependency on `{}`.",
+                "\x1b[34m{}\x1b[0m:{}:{}\nDependency violation: `{}` belongs to `{}`, but `{}` does not specify a dependency on `{}`.",
                 reference.relative_referencing_file,
                 reference.source_location.line,
                 reference.source_location.column,

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use super::output_helper::print_reference_location;
 use super::{CheckerInterface, ValidatorInterface, ViolationIdentifier};
 use crate::packs::checker::Reference;
 use crate::packs::pack::Pack;
@@ -164,11 +165,10 @@ impl CheckerInterface for Checker {
         // To receive help interpreting or resolving this error message, see: https://github.com/Shopify/packwerk/blob/main/TROUBLESHOOT.md#Troubleshooting-violations
         // END: Original packwerk message
 
+        let loc = print_reference_location(reference);
         let message = format!(
-                "\x1b[34m{}\x1b[0m:{}:{}\nDependency violation: `{}` belongs to `{}`, but `{}` does not specify a dependency on `{}`.",
-                reference.relative_referencing_file,
-                reference.source_location.line,
-                reference.source_location.column,
+                "{}Dependency violation: `{}` belongs to `{}`, but `{}` does not specify a dependency on `{}`.",
+                loc,
                 reference.constant_name,
                 defining_pack_name,
                 referencing_pack.relative_yml().to_string_lossy(),

--- a/src/packs/checker/folder_visibility.rs
+++ b/src/packs/checker/folder_visibility.rs
@@ -32,7 +32,7 @@ impl CheckerInterface for Checker {
 
         if !folder_visible(referencing_pack, defining_pack) {
             let message = format!(
-                "{}:{}:{}\nFolder Visibility violation: `{}` belongs to `{}`, which is not visible to `{}` as it is not a sibling pack or parent pack.",
+                "\x1b[34m{}\x1b[0m:{}:{}\nFolder Visibility violation: `{}` belongs to `{}`, which is not visible to `{}` as it is not a sibling pack or parent pack.",
                 reference.relative_referencing_file,
                 reference.source_location.line,
                 reference.source_location.column,

--- a/src/packs/checker/folder_visibility.rs
+++ b/src/packs/checker/folder_visibility.rs
@@ -1,3 +1,4 @@
+use super::output_helper::print_reference_location;
 use super::{CheckerInterface, ViolationIdentifier};
 use crate::packs::checker::reference::Reference;
 use crate::packs::pack::Pack;
@@ -31,11 +32,11 @@ impl CheckerInterface for Checker {
         }
 
         if !folder_visible(referencing_pack, defining_pack) {
+            let loc = print_reference_location(reference);
+
             let message = format!(
-                "\x1b[34m{}\x1b[0m:{}:{}\nFolder Visibility violation: `{}` belongs to `{}`, which is not visible to `{}` as it is not a sibling pack or parent pack.",
-                reference.relative_referencing_file,
-                reference.source_location.line,
-                reference.source_location.column,
+                "{}Folder Visibility violation: `{}` belongs to `{}`, which is not visible to `{}` as it is not a sibling pack or parent pack.",
+                loc,
                 reference.constant_name,
                 defining_pack.name,
                 referencing_pack.name,

--- a/src/packs/checker/layer.rs
+++ b/src/packs/checker/layer.rs
@@ -1,3 +1,4 @@
+use super::output_helper::print_reference_location;
 use super::{CheckerInterface, ValidatorInterface, ViolationIdentifier};
 use crate::packs::checker::Reference;
 use crate::packs::pack::{CheckerSetting, Pack};
@@ -189,11 +190,11 @@ impl CheckerInterface for Checker {
                     return Ok(None);
                 }
 
+                let loc = print_reference_location(reference);
+
                 let message = format!(
-                    "\x1b[34m{}\x1b[0m:{}:{}\n{} violation: `{}` belongs to `{}` (whose layer is `{}`) cannot be accessed from `{}` (whose layer is `{}`)",
-                    reference.relative_referencing_file,
-                    reference.source_location.line,
-                    reference.source_location.column,
+                    "{}{} violation: `{}` belongs to `{}` (whose layer is `{}`) cannot be accessed from `{}` (whose layer is `{}`)",
+                    loc,
                     self.layers.violation_name(),
                     reference.constant_name,
                     defining_pack_name,

--- a/src/packs/checker/layer.rs
+++ b/src/packs/checker/layer.rs
@@ -190,7 +190,7 @@ impl CheckerInterface for Checker {
                 }
 
                 let message = format!(
-                    "{}:{}:{}\n{} violation: `{}` belongs to `{}` (whose layer is `{}`) cannot be accessed from `{}` (whose layer is `{}`)",
+                    "\x1b[34m{}\x1b[0m:{}:{}\n{} violation: `{}` belongs to `{}` (whose layer is `{}`) cannot be accessed from `{}` (whose layer is `{}`)",
                     reference.relative_referencing_file,
                     reference.source_location.line,
                     reference.source_location.column,

--- a/src/packs/checker/output_helper.rs
+++ b/src/packs/checker/output_helper.rs
@@ -2,7 +2,7 @@ use super::reference::Reference;
 
 pub fn print_reference_location(reference: &Reference) -> String {
     format!(
-        "\x1b[34m{}\x1b[0m:{}:{}\n",
+        "\x1b[36m{}\x1b[0m:{}:{}\n",
         reference.relative_referencing_file,
         reference.source_location.line,
         reference.source_location.column,

--- a/src/packs/checker/output_helper.rs
+++ b/src/packs/checker/output_helper.rs
@@ -1,0 +1,10 @@
+use super::reference::Reference;
+
+pub fn print_reference_location(reference: &Reference) -> String {
+    format!(
+        "\x1b[34m{}\x1b[0m:{}:{}\n",
+        reference.relative_referencing_file,
+        reference.source_location.line,
+        reference.source_location.column,
+    )
+}

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -96,7 +96,7 @@ impl CheckerInterface for Checker {
         // END: Original packwerk message
 
         let message = format!(
-            "{}:{}:{}\nPrivacy violation: `{}` is private to `{}`, but referenced from `{}`",
+            "\x1b[34m{}\x1b[0m:{}:{}\nPrivacy violation: `{}` is private to `{}`, but referenced from `{}`",
             reference.relative_referencing_file,
             reference.source_location.line,
             reference.source_location.column,

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -1,3 +1,4 @@
+use super::output_helper::print_reference_location;
 use super::{CheckerInterface, ViolationIdentifier};
 use crate::packs::checker::Reference;
 use crate::packs::{Configuration, Violation};
@@ -94,12 +95,11 @@ impl CheckerInterface for Checker {
         // Inference details: this is a reference to ::Constant which seems to be defined in packs/defining_pack/path/to/definition.rb.
         // To receive help interpreting or resolving this error message, see: https://github.com/Shopify/packwerk/blob/main/TROUBLESHOOT.md#Troubleshooting-violations
         // END: Original packwerk message
+        let loc = print_reference_location(reference);
 
         let message = format!(
-            "\x1b[34m{}\x1b[0m:{}:{}\nPrivacy violation: `{}` is private to `{}`, but referenced from `{}`",
-            reference.relative_referencing_file,
-            reference.source_location.line,
-            reference.source_location.column,
+            "{}Privacy violation: `{}` is private to `{}`, but referenced from `{}`",
+            loc,
             reference.constant_name,
             defining_pack_name,
             referencing_pack_name,

--- a/src/packs/checker/visibility.rs
+++ b/src/packs/checker/visibility.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use super::output_helper::print_reference_location;
 use super::{CheckerInterface, ViolationIdentifier};
 use crate::packs::checker::Reference;
 use crate::packs::{Configuration, Violation};
@@ -56,12 +57,11 @@ impl CheckerInterface for Checker {
         )? {
             return Ok(None);
         }
+        let loc = print_reference_location(reference);
 
         let message = format!(
-            "\x1b[34m{}\x1b[0m:{}:{}\nVisibility violation: `{}` belongs to `{}`, which is not visible to `{}`",
-            reference.relative_referencing_file,
-            reference.source_location.line,
-            reference.source_location.column,
+            "{}Visibility violation: `{}` belongs to `{}`, which is not visible to `{}`",
+            loc,
             reference.constant_name,
             defining_pack_name,
             referencing_pack_name,

--- a/src/packs/checker/visibility.rs
+++ b/src/packs/checker/visibility.rs
@@ -58,7 +58,7 @@ impl CheckerInterface for Checker {
         }
 
         let message = format!(
-            "{}:{}:{}\nVisibility violation: `{}` belongs to `{}`, which is not visible to `{}`",
+            "\x1b[34m{}\x1b[0m:{}:{}\nVisibility violation: `{}` belongs to `{}`, which is not visible to `{}`",
             reference.relative_referencing_file,
             reference.source_location.line,
             reference.source_location.column,

--- a/tests/architecture_violations_test.rs
+++ b/tests/architecture_violations_test.rs
@@ -1,20 +1,25 @@
 use assert_cmd::prelude::*;
-use predicates::prelude::*;
 use std::{error::Error, process::Command};
 
 mod common;
-
 #[test]
 fn test_check() -> Result<(), Box<dyn Error>> {
-    Command::cargo_bin("packs")?
+    let output = Command::cargo_bin("packs")?
         .arg("--project-root")
         .arg("tests/fixtures/architecture_violations")
         .arg("--debug")
         .arg("check")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("1 violation(s) detected:"))
-        .stdout(predicate::str::contains("packs/feature_flags/app/services/feature_flags.rb:2:0\nArchitecture violation: `::Payments` belongs to `packs/payments` (whose layer is `product`) cannot be accessed from `packs/feature_flags` (whose layer is `utilities`)"));
+        .get_output()
+        .stdout
+        .clone();
+
+    let stripped_output =
+        String::from_utf8_lossy(&strip_ansi_escapes::strip(output)).to_string();
+
+    assert!(stripped_output.contains("1 violation(s) detected:"));
+    assert!(stripped_output.contains("packs/feature_flags/app/services/feature_flags.rb:2:0\nArchitecture violation: `::Payments` belongs to `packs/payments` (whose layer is `product`) cannot be accessed from `packs/feature_flags` (whose layer is `utilities`)"));
 
     common::teardown();
     Ok(())

--- a/tests/check_test.rs
+++ b/tests/check_test.rs
@@ -4,18 +4,28 @@ use std::{error::Error, fs};
 
 mod common;
 
+pub fn stripped_output(output: Vec<u8>) -> String {
+    String::from_utf8_lossy(&strip_ansi_escapes::strip(output)).to_string()
+}
+
 #[test]
 fn test_check() -> Result<(), Box<dyn Error>> {
-    Command::cargo_bin("packs")?
+    let output = Command::cargo_bin("packs")?
         .arg("--project-root")
         .arg("tests/fixtures/simple_app")
         .arg("--debug")
         .arg("check")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("2 violation(s) detected:"))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
+        .get_output()
+        .stdout
+        .clone();
+
+    let stripped_output = stripped_output(output);
+
+    assert!(stripped_output.contains("2 violation(s) detected:"));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
 
     common::teardown();
     Ok(())
@@ -23,7 +33,7 @@ fn test_check() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_check_with_single_file() -> Result<(), Box<dyn Error>> {
-    Command::cargo_bin("packs")?
+    let output = Command::cargo_bin("packs")?
         .arg("--project-root")
         .arg("tests/fixtures/simple_app")
         .arg("--debug")
@@ -31,9 +41,15 @@ fn test_check_with_single_file() -> Result<(), Box<dyn Error>> {
         .arg("packs/foo/app/services/foo.rb")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("2 violation(s) detected:"))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
+        .get_output()
+        .stdout
+        .clone();
+
+    let stripped_output = stripped_output(output);
+
+    assert!(stripped_output.contains("2 violation(s) detected:"));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
 
     common::teardown();
     Ok(())
@@ -42,7 +58,7 @@ fn test_check_with_single_file() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_check_with_single_file_experimental_parser(
 ) -> Result<(), Box<dyn Error>> {
-    Command::cargo_bin("packs")?
+    let output = Command::cargo_bin("packs")?
         .arg("--project-root")
         .arg("tests/fixtures/simple_app")
         .arg("--debug")
@@ -51,9 +67,15 @@ fn test_check_with_single_file_experimental_parser(
         .arg("packs/foo/app/services/foo.rb")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("2 violation(s) detected:"))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
+        .get_output()
+        .stdout
+        .clone();
+
+    let stripped_output = stripped_output(output);
+
+    assert!(stripped_output.contains("2 violation(s) detected:"));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
 
     common::teardown();
     Ok(())
@@ -78,7 +100,7 @@ fn test_check_with_package_todo_file() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_check_with_package_todo_file_ignoring_recorded_violations(
 ) -> Result<(), Box<dyn Error>> {
-    Command::cargo_bin("packs")?
+    let output = Command::cargo_bin("packs")?
         .arg("--project-root")
         .arg("tests/fixtures/contains_package_todo")
         .arg("--debug")
@@ -86,9 +108,14 @@ fn test_check_with_package_todo_file_ignoring_recorded_violations(
         .arg("--ignore-recorded-violations")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("2 violation(s) detected:"))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
-        .stdout(predicate::str::contains("packs/foo/app/services/other_foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
+        .get_output()
+        .stdout
+        .clone();
+
+    let stripped_output = stripped_output(output);
+    assert!(stripped_output.contains("2 violation(s) detected:"));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
+    assert!(stripped_output.contains("packs/foo/app/services/other_foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
 
     common::teardown();
 
@@ -97,7 +124,7 @@ fn test_check_with_package_todo_file_ignoring_recorded_violations(
 
 #[test]
 fn test_check_with_experimental_parser() -> Result<(), Box<dyn Error>> {
-    Command::cargo_bin("packs")
+    let output = Command::cargo_bin("packs")
         .unwrap()
         .arg("--project-root")
         .arg("tests/fixtures/simple_app")
@@ -106,9 +133,15 @@ fn test_check_with_experimental_parser() -> Result<(), Box<dyn Error>> {
         .arg("check")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("2 violation(s) detected:"))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
+        .get_output()
+        .stdout
+        .clone();
+
+    let stripped_output = stripped_output(output);
+
+    assert!(stripped_output.contains("2 violation(s) detected:"));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:3:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:3:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
 
     common::teardown();
     Ok(())
@@ -196,7 +229,7 @@ fn test_check_contents() -> Result<(), Box<dyn Error>> {
     let foo_rb_contents =
         fs::read_to_string(format!("{}/{}", project_root, relative_path))?;
 
-    Command::cargo_bin("packs")?
+    let output = Command::cargo_bin("packs")?
         .arg("--project-root")
         .arg(project_root)
         .arg("--debug")
@@ -205,9 +238,15 @@ fn test_check_contents() -> Result<(), Box<dyn Error>> {
         .write_stdin(format!("\n\n\n{}", foo_rb_contents))
         .assert()
         .failure()
-        .stdout(predicate::str::contains("2 violation(s) detected:"))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:6:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:6:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
+        .get_output()
+        .stdout
+        .clone();
+
+    let stripped_output = stripped_output(output);
+
+    assert!(stripped_output.contains("2 violation(s) detected:"));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:6:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:6:4\nPrivacy violation: `::Bar` is private to `packs/bar`, but referenced from `packs/foo`"));
 
     common::teardown();
     Ok(())
@@ -221,7 +260,7 @@ fn test_check_contents_ignoring_recorded_violations(
     let foo_rb_contents =
         fs::read_to_string(format!("{}/{}", project_root, relative_path))?;
 
-    Command::cargo_bin("packs")?
+    let output = Command::cargo_bin("packs")?
         .arg("--project-root")
         .arg(project_root)
         .arg("--debug")
@@ -231,8 +270,13 @@ fn test_check_contents_ignoring_recorded_violations(
         .write_stdin(format!("\n\n\n{}", foo_rb_contents))
         .assert()
         .failure()
-        .stdout(predicate::str::contains("1 violation(s) detected:"))
-        .stdout(predicate::str::contains("packs/foo/app/services/foo.rb:6:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
+        .get_output()
+        .stdout
+        .clone();
+
+    let stripped_output = stripped_output(output);
+    assert!(stripped_output.contains("1 violation(s) detected:"));
+    assert!(stripped_output.contains("packs/foo/app/services/foo.rb:6:4\nDependency violation: `::Bar` belongs to `packs/bar`, but `packs/foo/package.yml` does not specify a dependency on `packs/bar`."));
 
     common::teardown();
     Ok(())


### PR DESCRIPTION
Much more readable

- **Make the file names blue like packwerk**
- **extract out helper**
- **fix common test to make it strip colors**
- **make one integration test strip colors**
- **update other tests**
- **version**
