### PR TITLE
Simplifying new version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,13 +108,13 @@ jobs:
   upload-mac-universal-bin:
     needs: release
     runs-on: macos-latest
-    if: github.ref == 'refs/heads/main' && ${{needs.release.outputs.changed}} == 'true'
+    if: ${{needs.release.outputs.new_version}}
     steps:
       - uses: actions/checkout@v3
       - name: Build
         run: cargo build --release --target aarch64-apple-darwin --target x86_64-apple-darwin
 
-      - name: create GitHub Release
+      - name: Upload mac universal binary
         run: |
           # This combines the intel and m1 binaries into a single binary
           lipo -create -output target/packs target/aarch64-apple-darwin/release/packs target/x86_64-apple-darwin/release/packs
@@ -134,7 +134,7 @@ jobs:
 
   upload-linux-bin:
     needs: release
-    if: github.ref == 'refs/heads/main' && ${{needs.release.outputs.changed}} == 'true'
+    if: ${{needs.release.outputs.new_version}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -161,7 +161,7 @@ jobs:
       - release
       - upload-linux-bin
       - upload-mac-universal-bin
-    if: success() && github.ref == 'refs/heads/main' && ${{needs.release.outputs.changed}} == 'true'
+    if: success() && ${{needs.release.outputs.new_version}}
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
I believe this [fixes](https://github.com/perryqh/packs-ci/actions/runs/9571584049) the CI pipeline when the Cargo.toml version hasn't changed.