### PR TITLE
Add reason to enforcement ignores

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ enforcement_globs_ignore:
   - "**/*"
   # Enforce incoming privacy and visibility violation references _only_ in `packs/product_services/serv1/**/*`
   - "!packs/product_services/serv1/**/*"
+  reason: "It was decided only to fix incoming violations from serv1. See ticket #232"
 ```
 
 ```yml
@@ -149,6 +150,7 @@ enforcement_globs_ignore:
   - "**/*"
   # Enforce outgoing dependency violation references _only_ to `packs/pack3/**/*`
   - "!packs/pack3/**/*"
+  reason: "The other dependency violations are fine as those packs will be absorbed into this one."
 ```
 
 # Benchmarks

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -299,6 +299,7 @@ mod tests {
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
+                    reason: "deprecated".to_string(),
                 }]),
                 ..default_referencing_pack()
             },

--- a/src/packs/checker/folder_privacy.rs
+++ b/src/packs/checker/folder_privacy.rs
@@ -120,6 +120,7 @@ mod tests {
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
+                    reason: "deprecated".to_string(),
                 }]),
                 ..default_defining_pack()
             }),

--- a/src/packs/checker/layer.rs
+++ b/src/packs/checker/layer.rs
@@ -318,6 +318,7 @@ mod tests {
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
+                    reason: "deprecated".to_string(),
                 }]),
                 ..default_referencing_pack()
             },

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -233,6 +233,7 @@ mod tests {
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
+                    reason: "deprecated".to_string(),
                 }]),
                 ..default_defining_pack()
             }),

--- a/src/packs/checker/visibility.rs
+++ b/src/packs/checker/visibility.rs
@@ -131,6 +131,7 @@ mod tests {
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
+                    reason: "foo is deprecated".to_string(),
                 }]),
                 ..default_defining_pack()
             }),

--- a/src/packs/pack.rs
+++ b/src/packs/pack.rs
@@ -149,6 +149,11 @@ pub struct EnforcementGlobsIgnore {
         skip_serializing_if = "HashSet::is_empty"
     )]
     pub ignores: HashSet<String>,
+
+    #[serde(
+        default
+    )]
+    pub reason: String,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Deserialize, Serialize, Clone)]
@@ -640,10 +645,12 @@ enforcement_globs_ignore:
     ignores:
       - "**/*"
       - "!packs/foo"
+    reason: "deprecated foo"
   - enforcements:
       - layer
     ignores:
       - packs/bar
+    reason: "deprecated bar"
         "#
         .trim_start();
 
@@ -661,6 +668,7 @@ enforcement_globs_ignore:
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
+                    reason: "deprecated foo".to_string(),
                 },
                 EnforcementGlobsIgnore {
                     enforcements: ["layer"]
@@ -671,6 +679,7 @@ enforcement_globs_ignore:
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
+                    reason: "deprecated bar".to_string(),
                 },
             ]
         );

--- a/src/packs/pack.rs
+++ b/src/packs/pack.rs
@@ -150,9 +150,7 @@ pub struct EnforcementGlobsIgnore {
     )]
     pub ignores: HashSet<String>,
 
-    #[serde(
-        default
-    )]
+    #[serde(default)]
     pub reason: String,
 }
 


### PR DESCRIPTION
Adding a new `reason` field to `enforcement_globs_ignore`

Example:
```yml
enforcement_globs_ignore:
- enforcements:
  - privacy
  - visiblity
  ignores:
  - "**/*"
  - "!packs/product_services/serv1/**/*"
  reason: "It was decided only to fix incoming violations from serv1. See ticket #232"
```