### PR TITLE
Fixing create-when-exists race condition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/tests/create_test.rs
+++ b/tests/create_test.rs
@@ -58,7 +58,7 @@ See https://github.com/rubyatscale/packs#readme for more info!");
 fn test_create_already_exists() -> Result<(), Box<dyn Error>> {
     Command::cargo_bin("packs")?
         .arg("--project-root")
-        .arg("tests/fixtures/simple_app")
+        .arg("tests/fixtures/simple_packs_first_app")
         .arg("create")
         .arg("packs/foo")
         .assert()


### PR DESCRIPTION
### Background
The `0.2.10` [test suite](https://github.com/alexevanczuk/packs/actions/runs/9718013657/job/26824933932) failed because of a timing issue.
<img width="789" alt="Screenshot 2024-07-02 at 07 47 12" src="https://github.com/alexevanczuk/packs/assets/119452/5dbdd907-3f6b-421b-924e-fa40196a4b80">

I believe that `test_create_already_exists` ran before `test_create` had finished  `common::delete_foobar();`

### Change
`test_create_already_exists` now uses a different fixture
