### PR TITLE
Custom interpolation to allow for eventual overrides

### DIFF
--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use super::output_helper::print_reference_location;
 use super::pack_checker::PackChecker;
 use super::{CheckerInterface, ValidatorInterface};
 use crate::packs::checker::Reference;
@@ -153,21 +152,8 @@ impl CheckerInterface for Checker {
         // Inference details: this is a reference to ::Constant which seems to be defined in packs/defining_pack/path/to/definition.rb.
         // To receive help interpreting or resolving this error message, see: https://github.com/Shopify/packwerk/blob/main/TROUBLESHOOT.md#Troubleshooting-violations
         // END: Original packwerk message
-
-        let loc = print_reference_location(reference);
-        let message = format!(
-                "{}Dependency violation: `{}` belongs to `{}`, but `{}` does not specify a dependency on `{}`.",
-                loc,
-                reference.constant_name,
-                defining_pack.name,
-                pack_checker.referencing_pack.relative_yml().to_string_lossy(),
-                defining_pack.name,
-            );
-
-        Ok(Some(Violation {
-            message,
-            identifier: pack_checker.violation_identifier(),
-        }))
+        let violation_message = "{{reference_location}}Dependency violation: `{{constant_name}}` belongs to `{{defining_pack_name}}`, but `{{referencing_pack_relative_yml}}` does not specify a dependency on `{{defining_pack_name}}`.";
+        pack_checker.violation(violation_message)
     }
 
     fn violation_type(&self) -> String {

--- a/src/packs/checker/folder_privacy.rs
+++ b/src/packs/checker/folder_privacy.rs
@@ -1,4 +1,3 @@
-use super::output_helper::print_reference_location;
 use super::pack_checker::PackChecker;
 use super::CheckerInterface;
 use crate::packs::checker::reference::Reference;
@@ -21,20 +20,8 @@ impl CheckerInterface for Checker {
         let defining_pack = pack_checker.defining_pack.unwrap();
 
         if !folder_visible(pack_checker.referencing_pack, defining_pack) {
-            let loc = print_reference_location(reference);
-
-            let message = format!(
-                "{}Folder Privacy violation: `{}` belongs to `{}`, which is private to `{}` as it is not a sibling pack or parent pack.",
-                loc,
-                reference.constant_name,
-                defining_pack.name,
-                pack_checker.referencing_pack.name,
-            );
-
-            Ok(Some(Violation {
-                message,
-                identifier: pack_checker.violation_identifier(),
-            }))
+            let violation_message = "{{reference_location}}Folder Privacy violation: `{{constant_name}}` belongs to `{{defining_pack_name}}`, which is private to `{{referencing_pack_name}}` as it is not a sibling pack or parent pack.";
+            pack_checker.violation(violation_message)
         } else {
             Ok(None)
         }

--- a/src/packs/checker/layer.rs
+++ b/src/packs/checker/layer.rs
@@ -1,4 +1,3 @@
-use super::output_helper::print_reference_location;
 use super::pack_checker::PackChecker;
 use super::{CheckerInterface, ValidatorInterface};
 use crate::packs::checker::Reference;
@@ -12,7 +11,6 @@ pub struct Layers {
 }
 
 const VIOLATION_TYPE: &str = "layer";
-const VIOLATION_NAME: &str = "Layer";
 
 impl Layers {
     fn can_depend_on(
@@ -48,10 +46,6 @@ impl Layers {
 
     fn violation_type(&self) -> String {
         VIOLATION_TYPE.to_string()
-    }
-
-    fn violation_name(&self) -> String {
-        VIOLATION_NAME.to_string()
     }
 }
 
@@ -125,23 +119,13 @@ impl CheckerInterface for Checker {
                     return Ok(None);
                 }
 
-                let loc = print_reference_location(reference);
-
-                let message = format!(
-                    "{}{} violation: `{}` belongs to `{}` (whose layer is `{}`) cannot be accessed from `{}` (whose layer is `{}`)",
-                    loc,
-                    self.layers.violation_name(),
-                    reference.constant_name,
-                    defining_pack.name,
-                    defining_layer,
-                    pack_checker.referencing_pack.name,
-                    referencing_layer,
-                );
-
-                Ok(Some(Violation {
-                    message,
-                    identifier: pack_checker.violation_identifier(),
-                }))
+                // using `push_str` because `format!` changes `{{` to `{` and `}}` to `}`
+                let mut violation_message = "{{reference_location}}Layer violation: `{{constant_name}}` belongs to `{{defining_pack_name}}` (whose layer is `".to_string();
+                violation_message.push_str(defining_layer);
+                violation_message.push_str("`) cannot be accessed from `{{referencing_pack_name}}` (whose layer is `");
+                violation_message.push_str(referencing_layer);
+                violation_message.push_str("`)");
+                pack_checker.violation(&violation_message)
             }
             _ => Ok(None),
         }

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -1,4 +1,3 @@
-use super::output_helper::print_reference_location;
 use super::pack_checker::PackChecker;
 use super::CheckerInterface;
 use crate::packs::checker::Reference;
@@ -70,20 +69,8 @@ impl CheckerInterface for Checker {
         // Inference details: this is a reference to ::Constant which seems to be defined in packs/defining_pack/path/to/definition.rb.
         // To receive help interpreting or resolving this error message, see: https://github.com/Shopify/packwerk/blob/main/TROUBLESHOOT.md#Troubleshooting-violations
         // END: Original packwerk message
-        let loc = print_reference_location(reference);
-
-        let message = format!(
-            "{}Privacy violation: `{}` is private to `{}`, but referenced from `{}`",
-            loc,
-            reference.constant_name,
-            defining_pack.name,
-            &pack_checker.referencing_pack.name,
-        );
-
-        Ok(Some(Violation {
-            message,
-            identifier: pack_checker.violation_identifier(),
-        }))
+        let violation_message = "{{reference_location}}Privacy violation: `{{constant_name}}` is private to `{{defining_pack_name}}`, but referenced from `{{referencing_pack_name}}`";
+        pack_checker.violation(violation_message)
     }
 
     fn violation_type(&self) -> String {

--- a/src/packs/checker/visibility.rs
+++ b/src/packs/checker/visibility.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use super::output_helper::print_reference_location;
 use super::pack_checker::PackChecker;
 use super::CheckerInterface;
 use crate::packs::checker::Reference;
@@ -32,20 +31,8 @@ impl CheckerInterface for Checker {
             return Ok(None);
         }
 
-        let loc = print_reference_location(reference);
-
-        let message = format!(
-            "{}Visibility violation: `{}` belongs to `{}`, which is not visible to `{}`",
-            loc,
-            reference.constant_name,
-            defining_pack.name,
-            pack_checker.referencing_pack.name,
-        );
-
-        Ok(Some(Violation {
-            message,
-            identifier: pack_checker.violation_identifier(),
-        }))
+        let violation_message = "{{reference_location}}Visibility violation: `{{constant_name}}` belongs to `{{defining_pack_name}}`, which is not visible to `{{referencing_pack_name}}`";
+        pack_checker.violation(violation_message)
     }
 
     fn violation_type(&self) -> String {


### PR DESCRIPTION
## Why
In a subsequent PR, we want to add the ability to customize violation error messages.

#### Example:

Instead of 
> Folder Visibility violation: `::Foo::CategoryGroup` belongs to `packs/product_services/foo/bar`, which is private to `packs/product_services/zoo/you` as it is not a sibling pack or parent pack.

Allow for customization:
>  Product service boundary violation: `::Foo::CategoryGroup` belongs to the `packs/product_services/foo` product service and cannot be accessed directly from the `/packs/product_services/zoo` product service.  Use the `packs/product_services/foo/public_api`.



