### PR TITLE
Recurse into Const scope if unable to fetch const name

### DIFF
--- a/src/packs/parsing/ruby/experimental.rs
+++ b/src/packs/parsing/ruby/experimental.rs
@@ -425,4 +425,29 @@ end
 
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn mix_of_metaprogramming_and_regular_reference() {
+        let contents: String = String::from("Foo['bar']::Baz");
+        let configuration = Configuration::default();
+
+        std::assert_eq!(
+            process_from_contents(
+                contents,
+                &PathBuf::from("path/to/file.rb"),
+                &configuration,
+            )
+            .unresolved_references,
+            vec![UnresolvedReference {
+                name: String::from("Foo"),
+                namespace_path: vec![],
+                location: Range {
+                    start_row: 1,
+                    start_col: 0,
+                    end_row: 1,
+                    end_col: 4
+                }
+            }],
+        );
+    }
 }

--- a/src/packs/parsing/ruby/experimental/parser.rs
+++ b/src/packs/parsing/ruby/experimental/parser.rs
@@ -151,6 +151,9 @@ impl<'a> Visitor for ReferenceCollector<'a> {
 
     fn on_const(&mut self, node: &nodes::Const) {
         let Ok(name) = fetch_const_const_name(node) else {
+            if let Some(s) = &node.scope {
+                self.visit(s);
+            }
             return;
         };
 

--- a/src/packs/parsing/ruby/packwerk.rs
+++ b/src/packs/parsing/ruby/packwerk.rs
@@ -634,6 +634,31 @@ end
     }
 
     #[test]
+    fn mix_of_metaprogramming_and_regular_reference() {
+        let contents: String = String::from("Foo['bar']::Baz");
+        let configuration = Configuration::default();
+
+        assert_eq!(
+            process_from_contents(
+                contents,
+                &PathBuf::from("path/to/file.rb"),
+                &configuration,
+            )
+            .unresolved_references,
+            vec![UnresolvedReference {
+                name: String::from("Foo"),
+                namespace_path: vec![],
+                location: Range {
+                    start_row: 1,
+                    start_col: 0,
+                    end_row: 1,
+                    end_col: 4
+                }
+            }],
+        );
+    }
+
+    #[test]
     fn ignore_local_constant() {
         let contents: String = String::from(
             "\

--- a/src/packs/parsing/ruby/packwerk/parser.rs
+++ b/src/packs/parsing/ruby/packwerk/parser.rs
@@ -159,6 +159,9 @@ impl<'a> Visitor for ReferenceCollector<'a> {
 
     fn on_const(&mut self, node: &nodes::Const) {
         let Ok(name) = fetch_const_const_name(node) else {
+            if let Some(s) = &node.scope {
+                self.visit(s);
+            }
             return;
         };
 


### PR DESCRIPTION
I believe this fixes https://github.com/alexevanczuk/packs/issues/215.

`Bar::ADAPTER['default']::INSTANCE` is parsed as constant reference of `INSTANCE` with scope of `Bar::ADAPTER['default']`.

There used to be an assumption that if you encounter something other than a constant while recursing into the scope (in `fetch_const_const_name`), this constant reference should be ignored. However, we should instead recursively visit the scope to check if there any other constants there.

I thought of adding a test case for this, but I'm confused where to add it exactly.

<details>
<summary>Full AST of foo.rb</summary>

```rust
Class(
    Class {
        name: Const(
            Const {
                scope: None,
                name: "Foo",
                double_colon_l: None,
                name_l: 6...9,
                expression_l: 6...9,
            },
        ),
        superclass: None,
        body: Some(
            Def(
                Def {
                    name: "foo",
                    args: None,
                    body: Some(
                        Const(
                            Const {
                                scope: Some(
                                    Index(
                                        Index {
                                            recv: Const(
                                                Const {
                                                    scope: Some(
                                                        Const(
                                                            Const {
                                                                scope: None,
                                                                name: "Bar",
                                                                double_colon_l: None,
                                                                name_l: 64...67,
                                                                expression_l: 64...67,
                                                            },
                                                        ),
                                                    ),
                                                    name: "ADAPTER",
                                                    double_colon_l: Some(
                                                        67...69,
                                                    ),
                                                    name_l: 69...76,
                                                    expression_l: 64...76,
                                                },
                                            ),
                                            indexes: [
                                                Str(
                                                    Str {
                                                        value: Bytes {
                                                            raw: [
                                                                100,
                                                                101,
                                                                102,
                                                                97,
                                                                117,
                                                                108,
                                                                116,
                                                            ],
                                                        },
                                                        begin_l: Some(
                                                            77...78,
                                                        ),
                                                        end_l: Some(
                                                            85...86,
                                                        ),
                                                        expression_l: 77...86,
                                                    },
                                                ),
                                            ],
                                            begin_l: 76...77,
                                            end_l: 86...87,
                                            expression_l: 64...87,
                                        },
                                    ),
                                ),
                                name: "INSTANCE",
                                double_colon_l: Some(
                                    87...89,
                                ),
                                name_l: 89...97,
                                expression_l: 64...97,
                            },
                        ),
                    ),
                    keyword_l: 12...15,
                    name_l: 16...19,
                    end_l: Some(
                        100...103,
                    ),
                    assignment_l: None,
                    expression_l: 12...103,
                },
            ),
        ),
        keyword_l: 0...5,
        operator_l: None,
        end_l: 104...107,
        expression_l: 0...107,
    },
)
```

</details>