### PR TITLE
pack_public sigil should work with extension – read files if input included files is small

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.16"
+version = "0.2.17"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -45,13 +45,17 @@ impl CheckerInterface for Checker {
 
                 let manual_read_of_defining_file_contains_sigil =
                     if configuration.included_files.len() < 100 {
-                        let contents =
-                            std::fs::read_to_string(&absolute_file).unwrap();
-                        let sigils =
-                            ruby::parse_utils::extract_sigils_from_contents(
-                                &contents,
-                            );
-                        sigils.iter().any(|sigil| sigil.name == "public")
+                        if let Ok(contents) =
+                            std::fs::read_to_string(&absolute_file)
+                        {
+                            let sigils =
+                                ruby::parse_utils::extract_sigils_from_contents(
+                                    &contents,
+                                );
+                            sigils.iter().any(|sigil| sigil.name == "public")
+                        } else {
+                            false
+                        }
                     } else {
                         false
                     };

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -4,6 +4,7 @@ use super::output_helper::print_reference_location;
 use super::pack_checker::PackChecker;
 use super::CheckerInterface;
 use crate::packs::checker::Reference;
+use crate::packs::parsing::ruby;
 use crate::packs::{Configuration, Violation};
 
 pub struct Checker {}
@@ -38,10 +39,28 @@ impl CheckerInterface for Checker {
                 let absolute_file =
                     configuration.absolute_root.join(relative_file);
 
+                // if configuration.included_files is less than 100, we're just going to individually
+                // take the contents of the absolute file and call extract_sigils_from_contents on it to get the sigils
+                // and then check if a "public" sigil is contained. manual_read_of_defining_file_contains_sigil
+
+                let manual_read_of_defining_file_contains_sigil =
+                    if configuration.included_files.len() < 100 {
+                        let contents =
+                            std::fs::read_to_string(&absolute_file).unwrap();
+                        let sigils =
+                            ruby::parse_utils::extract_sigils_from_contents(
+                                &contents,
+                            );
+                        sigils.iter().any(|sigil| sigil.name == "public")
+                    } else {
+                        false
+                    };
+
                 // Check if the relative file starts with `public_folder` or the absolute file is in `sigils`
                 relative_file
                     .starts_with(public_folder.to_string_lossy().as_ref())
                     || sigils.contains_key(&absolute_file)
+                    || manual_read_of_defining_file_contains_sigil
             })
             .unwrap_or(false);
 

--- a/src/packs/parsing/ruby/mod.rs
+++ b/src/packs/parsing/ruby/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod experimental;
 mod inflector_shim;
 mod namespace_calculator;
 pub(crate) mod packwerk;
-mod parse_utils;
+pub(crate) mod parse_utils;
 mod rails_utils;
 mod ruby_utils;
 pub(crate) mod zeitwerk;

--- a/tests/public_sigil_test.rs
+++ b/tests/public_sigil_test.rs
@@ -41,6 +41,47 @@ Privacy violation: `::Bar::Api3` is private to `packs/bar`, but referenced from 
 }
 
 #[test]
+// The intent of this test is to capture the fact that if we pass in a single file to the command,
+// it will actually read the file to find the sigil. We normally don't do this when pks is run on the whole
+// codebase to prevent a second pass of reading files, but its essential to the extension working correctly,
+// since it only takes a subset of input files.
+fn test_pack_with_public_api_exposed_via_sigil_with_single_fine_input(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::cargo_bin("packs")?
+        .arg("--project-root")
+        .arg("tests/fixtures/public_api_sigils")
+        .arg("--debug")
+        .arg("check")
+        .arg("packs/foo/app/domain/foo/api.rb")
+        .output()?; // Capture the output
+
+    // Convert stdout to a string for comparison
+    let stdout_with_ansi = String::from_utf8_lossy(&output.stdout);
+
+    // Regex to remove ANSI escape sequences
+    let ansi_escape =
+        Regex::new(r"\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]").unwrap();
+    let stdout = ansi_escape.replace_all(&stdout_with_ansi, "");
+
+    // Define the expected output as a multiline string
+    let expected_output = r#"1 violation(s) detected:
+packs/foo/app/domain/foo/api.rb:7:8
+Privacy violation: `::Bar::Api3` is private to `packs/bar`, but referenced from `packs/foo`
+
+
+"#;
+
+    // Verify the process fails
+    assert!(!output.status.success());
+
+    // Verify the output matches the expected output exactly
+    assert_eq!(stdout, expected_output, "Unexpected output: {}", stdout);
+
+    common::teardown();
+    Ok(())
+}
+
+#[test]
 fn test_pack_with_public_api_exposed_via_sigil_with_experimental_parser(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let output = Command::cargo_bin("packs")?


### PR DESCRIPTION
The packwerk extension doesn't work with pks implementation of the public sigil, because the input file is a single file and we need to process the defining file that contains the sigil in order to "register" the sigil.

Packwerk solves this problem by just opening up every file and checking for the sigil. I did not want to do this by default in pks because we already have a pass of reading files, and not reading files again helps keep pks snappy.

However, in the extension, we always have a very small number of input files, so we can have a hard-coded exception there to actually read the files in those cases to keep the extension working.
