### PR TITLE
Use new configuration value for size of input files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod test_util {
         fixture_name: &str,
     ) -> anyhow::Result<Box<dyn ConstantResolver>> {
         let absolute_root = get_absolute_root(fixture_name);
-        let configuration = configuration::get(&absolute_root)?;
+        let configuration = configuration::get(&absolute_root, &10)?;
 
         Ok(get_zeitwerk_constant_resolver(
             &configuration.pack_set,
@@ -85,6 +85,7 @@ mod test_util {
                 &default_absolute_root,
                 RawConfiguration::default(),
                 walk_directory_result,
+                &0,
             )
             .unwrap() // TODO: potentially convert `default` to `new` and return a Result
         }

--- a/src/packs.rs
+++ b/src/packs.rs
@@ -214,7 +214,10 @@ pub fn add_dependency(
     // (which takes ownership over the previous one).
     // For now, we simply refetch the entire configuration for simplicity,
     // since we don't mind the slowdown for this CLI command.
-    let new_configuration = configuration::get(&configuration.absolute_root)?;
+    let new_configuration = configuration::get(
+        &configuration.absolute_root,
+        &configuration.input_files_count,
+    )?;
     let validation_result = packs::validate(&new_configuration);
     if validation_result.is_err() {
         println!("Added `{}` as a dependency to `{}`!", to, from);
@@ -238,9 +241,12 @@ pub fn validate(configuration: &Configuration) -> anyhow::Result<()> {
     checker::validate_all(configuration)
 }
 
-pub fn configuration(project_root: PathBuf) -> anyhow::Result<Configuration> {
+pub fn configuration(
+    project_root: PathBuf,
+    input_files_count: &usize,
+) -> anyhow::Result<Configuration> {
     let absolute_root = project_root.canonicalize()?;
-    configuration::get(&absolute_root)
+    configuration::get(&absolute_root, input_files_count)
 }
 
 pub fn check_unnecessary_dependencies(
@@ -439,6 +445,7 @@ mod tests {
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
+            &10,
         )
         .unwrap();
         let absolute_file_path = configuration

--- a/src/packs/caching/per_file_cache.rs
+++ b/src/packs/caching/per_file_cache.rs
@@ -119,7 +119,7 @@ mod tests {
 
     fn teardown() {
         packs::delete_cache(
-            configuration::get(&PathBuf::from("tests/fixtures/simple_app"))
+            configuration::get(&PathBuf::from("tests/fixtures/simple_app"), &1)
                 .unwrap(),
         );
     }

--- a/src/packs/checker/dependency.rs
+++ b/src/packs/checker/dependency.rs
@@ -317,6 +317,7 @@ mod tests {
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
+            &1,
         )
         .unwrap();
 
@@ -340,6 +341,7 @@ packs/foo, packs/bar",
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
+            &1,
         )
         .unwrap();
 
@@ -358,6 +360,7 @@ packs/foo, packs/bar",
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
+            &1,
         )
         .unwrap();
 

--- a/src/packs/checker/layer.rs
+++ b/src/packs/checker/layer.rs
@@ -472,6 +472,7 @@ mod tests {
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
+            &1,
         )
         .unwrap();
         let checker = Checker {

--- a/src/packs/checker/privacy.rs
+++ b/src/packs/checker/privacy.rs
@@ -39,12 +39,11 @@ impl CheckerInterface for Checker {
                 let absolute_file =
                     configuration.absolute_root.join(relative_file);
 
-                // if configuration.included_files is less than 100, we're just going to individually
+                // if configuration.input_files_count is less than 100, we're just going to individually
                 // take the contents of the absolute file and call extract_sigils_from_contents on it to get the sigils
                 // and then check if a "public" sigil is contained. manual_read_of_defining_file_contains_sigil
-
                 let manual_read_of_defining_file_contains_sigil =
-                    if configuration.included_files.len() < 100 {
+                    if configuration.input_files_count < 100 {
                         if let Ok(contents) =
                             std::fs::read_to_string(&absolute_file)
                         {
@@ -52,6 +51,7 @@ impl CheckerInterface for Checker {
                                 ruby::parse_utils::extract_sigils_from_contents(
                                     &contents,
                                 );
+
                             sigils.iter().any(|sigil| sigil.name == "public")
                         } else {
                             false

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -201,7 +201,8 @@ pub fn run() -> anyhow::Result<()> {
         packs::init(&absolute_root, use_packwerk)?
     }
 
-    let mut configuration = packs::configuration::get(&absolute_root)?;
+    // Input filesize TBD
+    let mut configuration = packs::configuration::get(&absolute_root, &0)?;
 
     if args.print_files {
         configuration.print_files = true;
@@ -266,6 +267,7 @@ pub fn run() -> anyhow::Result<()> {
         } => {
             configuration.ignore_recorded_violations =
                 ignore_recorded_violations;
+            configuration.input_files_count = files.len();
             packs::check(&configuration, files)
         }
         Command::CheckContents {
@@ -277,6 +279,7 @@ pub fn run() -> anyhow::Result<()> {
 
             let absolute_path = get_absolute_path(file.clone(), &configuration);
             configuration.stdin_file_path = Some(absolute_path);
+            configuration.input_files_count = 1;
             packs::check(&configuration, vec![file])
         }
         Command::Update => packs::update(&configuration),

--- a/src/packs/dependencies.rs
+++ b/src/packs/dependencies.rs
@@ -74,6 +74,7 @@ mod tests {
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
+                &0
         )
         .unwrap();
 
@@ -91,6 +92,7 @@ mod tests {
                 .canonicalize()
                 .expect("Could not canonicalize path")
                 .as_path(),
+                &0
         )
         .unwrap();
 

--- a/src/packs/monkey_patch_detection.rs
+++ b/src/packs/monkey_patch_detection.rs
@@ -252,9 +252,10 @@ These monkey patches redefine behavior in a pack within your app (as determined 
 </details>"
       );
 
-        let mut configuration = configuration::get(&PathBuf::from(
-            "tests/fixtures/app_with_monkey_patches",
-        ))
+        let mut configuration = configuration::get(
+            &PathBuf::from("tests/fixtures/app_with_monkey_patches"),
+            &0,
+        )
         .unwrap();
         configuration.experimental_parser = true;
         let actual_message = expose_monkey_patches(

--- a/src/packs/parsing/ruby/zeitwerk/mod.rs
+++ b/src/packs/parsing/ruby/zeitwerk/mod.rs
@@ -333,7 +333,7 @@ mod tests {
 
     fn teardown() {
         packs::delete_cache(
-            configuration::get(&PathBuf::from("tests/fixtures/simple_app"))
+            configuration::get(&PathBuf::from("tests/fixtures/simple_app"), &0)
                 .unwrap(),
         );
     }
@@ -487,7 +487,7 @@ mod tests {
             .canonicalize()
             .expect("Could not canonicalize path");
 
-        let configuration = configuration::get(absolute_root).unwrap();
+        let configuration = configuration::get(absolute_root, &0).unwrap();
 
         let constant_resolver = get_zeitwerk_constant_resolver(
             &configuration.pack_set,

--- a/tests/add_constant_dependencies.rs
+++ b/tests/add_constant_dependencies.rs
@@ -20,9 +20,10 @@ fn test_add_constant_dependencies() -> anyhow::Result<()> {
             "Successfully updated 1 dependency for constant '::Bar::Tender'",
         ));
 
-    let config = packs::packs::configuration(PathBuf::from(
-        "tests/fixtures/app_with_missing_dependencies",
-    ))
+    let config = packs::packs::configuration(
+        PathBuf::from("tests/fixtures/app_with_missing_dependencies"),
+        &0,
+    )
     .unwrap();
 
     let pack = config.pack_set.for_pack("packs/foo").unwrap();

--- a/tests/add_dependency_test.rs
+++ b/tests/add_dependency_test.rs
@@ -21,9 +21,10 @@ fn test_add_dependency() -> Result<(), Box<dyn Error>> {
             "Successfully added `packs/foo` as a dependency to `packs/baz`!",
         ));
 
-    let config = packs::packs::configuration(PathBuf::from(
-        "tests/fixtures/app_with_missing_dependency",
-    ))
+    let config = packs::packs::configuration(
+        PathBuf::from("tests/fixtures/app_with_missing_dependency"),
+        &0,
+    )
     .unwrap();
 
     let pack = config.pack_set.for_pack("packs/baz").unwrap();
@@ -61,9 +62,10 @@ fn test_add_dependency_creating_cycle() -> Result<(), Box<dyn Error>> {
         ))
         .stdout(predicate::str::contains("packs/foo, packs/bar"));
 
-    let config = packs::packs::configuration(PathBuf::from(
-        "tests/fixtures/app_with_missing_dependency",
-    ))
+    let config = packs::packs::configuration(
+        PathBuf::from("tests/fixtures/app_with_missing_dependency"),
+        &0,
+    )
     .unwrap();
 
     let pack = config.pack_set.for_pack("packs/bar").unwrap();
@@ -92,9 +94,10 @@ fn test_add_dependency_unnecessarily() -> Result<(), Box<dyn Error>> {
             "`packs/foo` already depends on `packs/bar`!",
         ));
 
-    let config = packs::packs::configuration(PathBuf::from(
-        "tests/fixtures/app_with_missing_dependency",
-    ))
+    let config = packs::packs::configuration(
+        PathBuf::from("tests/fixtures/app_with_missing_dependency"),
+        &0,
+    )
     .unwrap();
 
     let pack = config.pack_set.for_pack("packs/foo").unwrap();


### PR DESCRIPTION
In #220 I misunderstood `included_files` to be the input files – not just the total files that we are looking at when walking the directory.
