### PR TITLE
Attempt to fix corrupted constant_resolver.json cache issue breaking pks update and pks check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ ruby_inflector = '0.0.8'                                               # for inf
 petgraph = "0.6.3"                                                     # for running graph algorithms (e.g. does the dependency graph contain a cycle?)
 fnmatch-regex2 = "0.3.0"
 strip-ansi-escapes = "0.2.0"
+fs2 = "0.4.3"                                                         # for async file system operations, right now only concurrency control in writing the constant resolver cache
 
 [dev-dependencies]
 assert_cmd = "2.0.10"       # testing CLI

--- a/src/packs/parsing/ruby/zeitwerk/mod.rs
+++ b/src/packs/parsing/ruby/zeitwerk/mod.rs
@@ -280,7 +280,7 @@ fn inferred_constant_from_file(
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct ConstantResolverCache {
     file_definition_map: HashMap<PathBuf, String>,
 }
@@ -558,4 +558,122 @@ mod tests {
         assert_eq!(&expected_constant_map, actual_constant_map);
         teardown();
     }
+
+    #[test]
+    fn test_cache_constant_definitions() {
+        let absolute_root = &PathBuf::from("tests/fixtures/simple_app")
+            .canonicalize()
+            .expect("Could not canonicalize path");
+
+        let configuration = configuration::get(absolute_root, &0).unwrap();
+
+        let constant_resolver = get_zeitwerk_constant_resolver(
+            &configuration.pack_set,
+            &configuration.constant_resolver_configuration(),
+        );
+        let constants = constant_resolver
+            .fully_qualified_constant_name_to_constant_definition_map();
+
+        let cache_dir = configuration
+            .constant_resolver_configuration()
+            .cache_directory
+            .clone();
+        cache_constant_definitions(
+            &constants.values().flatten().cloned().collect(),
+            &cache_dir,
+            false,
+        );
+
+        let cache_data = get_constant_resolver_cache(&cache_dir);
+
+        // ~/workspace/packs - main ! $ tree tests/fixtures/simple_app
+        // tests/fixtures/simple_app
+        // ├── app
+        // │   ├── company_data
+        // │   │   └── widget.rb
+        // │   └── services
+        // │       └── some_root_class.rb
+        // ├── frontend
+        // │   └── ui_helper.rb
+        // ├── node_modules
+        // │   ├── file.rb
+        // │   └── subfolder
+        // │       └── file.rb
+        // ├── package.yml
+        // ├── packs
+        // │   ├── bar
+        // │   │   ├── app
+        // │   │   │   ├── models
+        // │   │   │   │   └── concerns
+        // │   │   │   │       └── some_concern.rb
+        // │   │   │   └── services
+        // │   │   │       └── bar.rb
+        // │   │   └── package.yml
+        // │   ├── baz
+        // │   │   ├── app
+        // │   │   │   └── services
+        // │   │   │       └── baz.rb
+        // │   │   └── package.yml
+        // │   └── foo
+        // │       ├── app
+        // │       │   ├── services
+        // │       │   │   ├── foo
+        // │       │   │   │   └── bar.rb
+        // │       │   │   └── foo.rb
+        // │       │   └── views
+        // │       │       └── foo.erb
+        // │       └── package.yml
+        // ├── packwerk.yml
+        // ├── script
+        // │   └── my_script.rb
+        // └── tmp
+        let mut expected_file_definition_map = HashMap::new();
+
+        expected_file_definition_map.insert(
+            absolute_root.join("packs/foo/app/services/foo.rb"),
+            "::Foo".to_string(),
+        );
+
+        expected_file_definition_map.insert(
+            absolute_root.join("packs/foo/app/services/foo/bar.rb"),
+            "::Foo::Bar".to_string(),
+        );
+
+        expected_file_definition_map.insert(
+            absolute_root.join("packs/bar/app/services/bar.rb"),
+            "::Bar".to_string(),
+        );
+
+        expected_file_definition_map.insert(
+            absolute_root.join("packs/bar/app/models/concerns/some_concern.rb"),
+            "::SomeConcern".to_string(),
+        );
+
+        expected_file_definition_map.insert(
+            absolute_root.join("packs/baz/app/services/baz.rb"),
+            "::Baz".to_string(),
+        );
+
+        expected_file_definition_map.insert(
+            absolute_root.join("app/services/some_root_class.rb"),
+            "::SomeRootClass".to_string(),
+        );
+
+        expected_file_definition_map.insert(
+            absolute_root.join("app/company_data/widget.rb"),
+            "::Company::Widget".to_string(),
+        );
+
+        assert_eq!(
+            ConstantResolverCache {
+                file_definition_map: expected_file_definition_map
+            },
+            cache_data
+        );
+
+        teardown();
+    }
+
+    use std::collections::HashMap;
+    use std::path::PathBuf;
 }


### PR DESCRIPTION
There's a persistent issue I'm seeing, it looks like this:
```
$ pks update
thread 'main' panicked at /Users/alexevanczuk/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pks-0.2.21/src/packs/parsing/ruby/zeitwerk/mod.rs:293:41:
called `Result::unwrap()` on an `Err` value: Error("EOF while parsing a value", line: 1, column: 0)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

It appears that the `constant_resolver.json` cache file is just an empty string.

I don't know why that is – nothing in the process intentionally will write an empty string – it should at least write *something*.

I suspect it has to do with some race condition across multiple processes when using the extension.

I'm hoping adding a file-exclusive lock on the cache file will fix this.

Note we don't really see this issue for individual file caches... which kind of makes sense, because I'd expect to see one process per file, i.e. no concurrent access to individual file caches, since the pks vscode extension is running each time a file is saved, so the same file has something that looks like serial access to its file cache, even while separate pks runs for different files are happening concurrently.

I'd love to write a test that fails but not quite sure how, so shipping this for now hoping it fixes the issue.
