### PR TITLE
Refuse to upgrade if not installed using cargo install

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "pks"
-version = "0.2.39"
+version = "0.2.40"
 edition = "2021"
 description = "Welcome! Please see https://github.com/alexevanczuk/packs for more information!"
 license = "MIT"

--- a/src/packs/cli.rs
+++ b/src/packs/cli.rs
@@ -283,6 +283,31 @@ pub fn run() -> anyhow::Result<()> {
     }
 
     if let Command::Upgrade = args.command {
+        let cargo_bin = std::env::var("CARGO_HOME")
+            .map(PathBuf::from)
+            .or_else(|_| {
+                std::env::var("HOME").map(|h| PathBuf::from(h).join(".cargo"))
+            })
+            .expect("Could not determine CARGO_HOME or HOME directory")
+            .join("bin");
+
+        let current_exe = std::env::current_exe()
+            .expect("Could not determine current executable path");
+
+        let canonical_exe =
+            current_exe.canonicalize().unwrap_or(current_exe.clone());
+        let canonical_cargo_bin =
+            cargo_bin.canonicalize().unwrap_or(cargo_bin.clone());
+
+        if !canonical_exe.starts_with(&canonical_cargo_bin) {
+            eprintln!(
+                "Error: `pks upgrade` only works when pks was installed via `cargo install`."
+            );
+            eprintln!("Current executable: {}", current_exe.display());
+            eprintln!("Expected location:  {}/", cargo_bin.display());
+            std::process::exit(1);
+        }
+
         let status = std::process::Command::new("cargo")
             .args(["install", "pks"])
             .status()?;


### PR DESCRIPTION
As discussed here: https://github.com/alexevanczuk/packs/pull/246#issuecomment-3943370807

Running `cargo install pks` if `pks` is not installed using `cargo install` would at best install a second copy of `pks`, won't even work at worst.

Written using Opus 4.6 with minor manual editing. Not sure if this path stuff would work on Windows, but I guess we're not targeting it at all? 😄 

@alexevanczuk 